### PR TITLE
Fix incorrect cycle counts for some bit-shift ops

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -166,6 +166,7 @@ M68KMAKE_TABLE_FOOTER
 void m68ki_build_opcode_table(void)
 {
 	opcode_handler_struct *ostruct;
+	int cycle_cost;
 	int instr;
 	int i;
 	int j;
@@ -213,8 +214,17 @@ void m68ki_build_opcode_table(void)
 				m68ki_instruction_jump_table[instr] = ostruct->opcode_handler;
 				for(k=0;k<NUM_CPU_TYPES;k++)
 					m68ki_cycles[k][instr] = ostruct->cycles[k];
+				// For all shift operations with known shift distance (encoded in instruction word)
 				if((instr & 0xf000) == 0xe000 && (!(instr & 0x20)))
-					m68ki_cycles[0][instr] = m68ki_cycles[1][instr] = ostruct->cycles[k] + ((((j-1)&7)+1)<<1);
+				{
+					// On the 68000 and 68010 shift distance affect execution time.
+					// Add the cycle cost of shifting; 2 times the shift distance
+					cycle_cost = ((((i-1)&7)+1)<<1);
+					m68ki_cycles[0][instr] += cycle_cost;
+					m68ki_cycles[1][instr] += cycle_cost;
+					// On the 68020 shift distance does not affect execution time
+					m68ki_cycles[2][instr] += 0;
+				}
 			}
 		}
 		ostruct++;


### PR DESCRIPTION
This PR fixes a bug in the adjustments made to the m68ki_cycles
table, for all shift operations with known shift distance (where the
shift distance is encoded in the instruction word).

More specifically, the expression "ostruct->cycles[k] + ((((j-1)&7)+1)<<1)" on line 217 had two problems; It's accessing the ostruct->cycles array out-of-bounds (as **k** is now 3) which happened to return zero, and also **j** is the wrong value for the in-instruction shift count (it represents DY here), the correct value is located in **i**.

Affects cycle counts for **ASL/ASR, LSL/LSR, ROL/ROR** and **ROXL/ROXR** on the
68000 and 68010 emulations.