### PR TITLE
Fix ADDA operand evaluation order

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -1227,9 +1227,10 @@ M68KMAKE_OP(adda, 16, ., a)
 
 M68KMAKE_OP(adda, 16, ., .)
 {
+	signed short src = MAKE_INT_16(M68KMAKE_GET_OPER_AY_16);
 	uint* r_dst = &AX;
 
-	*r_dst = MASK_OUT_ABOVE_32(*r_dst + MAKE_INT_16(M68KMAKE_GET_OPER_AY_16));
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + src);
 }
 
 
@@ -1251,9 +1252,10 @@ M68KMAKE_OP(adda, 32, ., a)
 
 M68KMAKE_OP(adda, 32, ., .)
 {
+	uint src = M68KMAKE_GET_OPER_AY_32;
 	uint* r_dst = &AX;
 
-	*r_dst = MASK_OUT_ABOVE_32(*r_dst + M68KMAKE_GET_OPER_AY_32);
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst + src);
 }
 
 


### PR DESCRIPTION

The ADDA _ea_, An instruction (both word and long variants) must
evaluate the source operand before the destination operand (_ea_ before
An), because in case of pi/pd addressing modes, the increment/decrement
side-effect to AY must happen **before** reading AX if both AX and AY
references the same register!

As an example, the operation ADDA.L (A0)+, A0 needs to be evaluated like;

	mem = read_long(A0);
	A0 += 4; // post-increment A0
	A0 += mem;

but now it might (explained below) be evaluated like;

	reg = A0
	mem = read_long(A0);
	A0 += 4; // post-increment A0
	A0 = reg + mem;

which overwrites the side-effect, and degenerates into ADDA.L (A0), A0.

Similarily ADDA.L -(A0), A0 degenerates into ADDA.L (-4, A0), A0.

ADDA.W is also affected in the same way. Expected ADDA behaviour was also double-checked with [EASy68k](http://www.easy68k.com).

In more detail, the ADDA.L instruction was using the expression;

	*r_dst = MASK_OUT_ABOVE_32(*r_dst + M68KMAKE_GET_OPER_AY_32);

And according to the [Wikipedia article on sequence points](https://en.wikipedia.org/wiki/Sequence_point) the evaluation order of the operands to + is undefined in C (compiler dependent), but we need M68KMAKE_GET_OPER_AY_32 to be evaluated before *r_dst, and so this bug may, or may not manifest in a particular executable, depending on the C compiler implementation details.

The fix should only have a observable effect on 16/32-bit ADDA in the pi/pd
addressing modes, but does also modify the implementation of ai, di, ix,
aw, al, pcdi, pcix and imm addressing modes, as they are all generated from
the modified M68KMAKE_OP-template.

This PR also fixes issue #7.