### PR TITLE
Fix SUBA operand evaluation order

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -9450,9 +9450,10 @@ M68KMAKE_OP(suba, 16, ., a)
 
 M68KMAKE_OP(suba, 16, ., .)
 {
+	signed short src = MAKE_INT_16(M68KMAKE_GET_OPER_AY_16);
 	uint* r_dst = &AX;
 
-	*r_dst = MASK_OUT_ABOVE_32(*r_dst - MAKE_INT_16(M68KMAKE_GET_OPER_AY_16));
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - src);
 }
 
 
@@ -9474,9 +9475,10 @@ M68KMAKE_OP(suba, 32, ., a)
 
 M68KMAKE_OP(suba, 32, ., .)
 {
+	uint src = M68KMAKE_GET_OPER_AY_32;
 	uint* r_dst = &AX;
 
-	*r_dst = MASK_OUT_ABOVE_32(*r_dst - M68KMAKE_GET_OPER_AY_32);
+	*r_dst = MASK_OUT_ABOVE_32(*r_dst - src);
 }
 
 


### PR DESCRIPTION
@emoon noticed that the operand evaluation order issue, fixed for ADDA in #10 was also present in SUBA. This PR contains the same fix for SUBA. I looked quickly at the other xxxA instructions as well but couldn't find any further issues.

The SUBA _ea_, An instruction (both word and long variants) must
evaluate the source operand before the destination operand (_ea_ before
An), because in case of pi/pd addressing modes, the increment/decrement
side-effect to AY must happen before reading AX if both AX and AY
references the same register!