### PR TITLE
Fix cycle count for DBF instruction

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -555,7 +555,7 @@ cpgen     32  .     .     1111...000......  ..........  . . U    .   .   4  unem
 cpscc     32  .     .     1111...001......  ..........  . . U    .   .   4  unemulated
 cptrapcc  32  .     .     1111...001111...  ..........  . . U    .   .   4  unemulated
 dbt       16  .     .     0101000011001...  ..........  U U U   12  12   6
-dbf       16  .     .     0101000111001...  ..........  U U U   14  14   6
+dbf       16  .     .     0101000111001...  ..........  U U U   12  12   6
 dbcc      16  .     .     0101....11001...  ..........  U U U   12  12   6
 divs      16  .     d     1000...111000...  ..........  U U U  158 122  56
 divs      16  .     .     1000...111......  A+-DXWLdxI  U U U  158 122  56
@@ -4391,9 +4391,11 @@ M68KMAKE_OP(dbf, 16, ., .)
 		REG_PC -= 2;
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		m68ki_branch_16(offset);
+		USE_CYCLES(CYC_DBCC_F_NOEXP);
 		return;
 	}
 	REG_PC += 2;
+	USE_CYCLES(CYC_DBCC_F_EXP);
 }
 
 


### PR DESCRIPTION
This PR modifies cycle counts for the DBF instruction, which previously was a fixed 14 cycles, to  consume either 10 or 14 cycles depending on if the branch was taken (10), or not (14). 

This is consistent with the behaviour of the other DBcc instructions, as well as when compared with EASy68k and current MAME Musashi, see [the DBF entry in M68KMAKE_TABLE_BODY](https://github.com/mamedev/mame/blob/master/src/devices/cpu/m68000/m68k_in.cpp#L550) and [M68KMAKE_OP implementation for DBF](https://github.com/mamedev/mame/blob/master/src/devices/cpu/m68000/m68k_in.cpp#L4501-L4505)