### PR TITLE
Fix incorrect Scc cycle count

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -9231,6 +9231,7 @@ M68KMAKE_OP(scc, 8, ., d)
 	if(M68KMAKE_CC)
 	{
 		DY |= 0xff;
+		USE_CYCLES(CYC_SCC_R_TRUE);
 		return;
 	}
 	DY &= 0xffffff00;

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -578,7 +578,7 @@ void m68k_set_cpu_type(unsigned int cpu_type)
 			CYC_BCC_NOTAKE_W = 2;
 			CYC_DBCC_F_NOEXP = -2;
 			CYC_DBCC_F_EXP   = 2;
-			CYC_SCC_R_FALSE  = 2;
+			CYC_SCC_R_TRUE   = 2;
 			CYC_MOVEM_W      = 2;
 			CYC_MOVEM_L      = 3;
 			CYC_SHIFT        = 1;
@@ -594,7 +594,7 @@ void m68k_set_cpu_type(unsigned int cpu_type)
 			CYC_BCC_NOTAKE_W = 0;
 			CYC_DBCC_F_NOEXP = 0;
 			CYC_DBCC_F_EXP   = 6;
-			CYC_SCC_R_FALSE  = 0;
+			CYC_SCC_R_TRUE   = 0;
 			CYC_MOVEM_W      = 2;
 			CYC_MOVEM_L      = 3;
 			CYC_SHIFT        = 1;
@@ -610,7 +610,7 @@ void m68k_set_cpu_type(unsigned int cpu_type)
 			CYC_BCC_NOTAKE_W = 0;
 			CYC_DBCC_F_NOEXP = 0;
 			CYC_DBCC_F_EXP   = 4;
-			CYC_SCC_R_FALSE  = 0;
+			CYC_SCC_R_TRUE   = 0;
 			CYC_MOVEM_W      = 2;
 			CYC_MOVEM_L      = 2;
 			CYC_SHIFT        = 0;
@@ -626,7 +626,7 @@ void m68k_set_cpu_type(unsigned int cpu_type)
 			CYC_BCC_NOTAKE_W = 0;
 			CYC_DBCC_F_NOEXP = 0;
 			CYC_DBCC_F_EXP   = 4;
-			CYC_SCC_R_FALSE  = 0;
+			CYC_SCC_R_TRUE   = 0;
 			CYC_MOVEM_W      = 2;
 			CYC_MOVEM_L      = 2;
 			CYC_SHIFT        = 0;

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -348,7 +348,7 @@
 #define CYC_BCC_NOTAKE_W m68ki_cpu.cyc_bcc_notake_w
 #define CYC_DBCC_F_NOEXP m68ki_cpu.cyc_dbcc_f_noexp
 #define CYC_DBCC_F_EXP   m68ki_cpu.cyc_dbcc_f_exp
-#define CYC_SCC_R_FALSE  m68ki_cpu.cyc_scc_r_false
+#define CYC_SCC_R_TRUE   m68ki_cpu.cyc_scc_r_true
 #define CYC_MOVEM_W      m68ki_cpu.cyc_movem_w
 #define CYC_MOVEM_L      m68ki_cpu.cyc_movem_l
 #define CYC_SHIFT        m68ki_cpu.cyc_shift
@@ -829,7 +829,7 @@ typedef struct
 	uint cyc_bcc_notake_w;
 	uint cyc_dbcc_f_noexp;
 	uint cyc_dbcc_f_exp;
-	uint cyc_scc_r_false;
+	uint cyc_scc_r_true;
 	uint cyc_movem_w;
 	uint cyc_movem_l;
 	uint cyc_shift;


### PR DESCRIPTION
The Scc instruction with a register operand takes two extra cycles when
the condition is true, on the 68000. On the 010/020 there are no such
penalty. 

There was already the macro CYC_SCC_R_FALSE, and a backing field, which was set to 2 for the 000, but it wasn't used in the Scc template, so I renamed that (and the backing field) to CYC_SCC_R_TRUE, and used that in the Scc template.