### PR TITLE
Fix JMP_32_IX cycle count

### DIFF
--- a/m68kmake.c
+++ b/m68kmake.c
@@ -347,7 +347,7 @@ int g_jmp_cycle_table[13] =
 	 0, /* EA_MODE_PD   */
 	 0, /* EA_MODE_PD7  */
 	 6, /* EA_MODE_DI   */
-	 8, /* EA_MODE_IX   */
+	 10, /* EA_MODE_IX   */
 	 6, /* EA_MODE_AW   */
 	 8, /* EA_MODE_AL   */
 	 6, /* EA_MODE_PCDI */


### PR DESCRIPTION
According to the M68000UM, JMP 32 ix should take 14 cycles, not 12, for
both the 68000 and 010. 

(A base cost of 4 is added to the value in the table, that's why it says 10, not 14)