### PR TITLE
Reset CPU_INSTR_MODE in m68k_pulse_reset

### DIFF
--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -765,6 +765,7 @@ void m68k_pulse_reset(void)
 	SET_CYCLES(0);
 
 	CPU_RUN_MODE = RUN_MODE_BERR_AERR_RESET;
+	CPU_INSTR_MODE = INSTRUCTION_YES;
 
 	/* Turn off tracing */
 	FLAG_T1 = FLAG_T0 = 0;


### PR DESCRIPTION
Or resetting when CPU_INSTR_MODE is set to INSTRUCTION_NO affects what
is pushed by address errors even after calling m68k_init,
m68k_set_cpu_type, and m68k_pulse_reset.