### PR TITLE
Don't let USE_ALL_CYCLES overspend cycles

### DIFF
--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -745,7 +745,7 @@
 #define USE_CYCLES(A)    m68ki_remaining_cycles -= (A)
 #define SET_CYCLES(A)    m68ki_remaining_cycles = A
 #define GET_CYCLES()     m68ki_remaining_cycles
-#define USE_ALL_CYCLES() m68ki_remaining_cycles = 0
+#define USE_ALL_CYCLES() m68ki_remaining_cycles %= CYC_INSTRUCTION[REG_IR]
 
 
 


### PR DESCRIPTION
Ok so this PR is perhaps a bit pedantic. But when running tests comparing instructions in [r68k](https://github.com/marhel/r68k), Musashi sometimes reported consuming an odd number of cycles for jump instructions!

After some investigation this was explained by the following;

When an branch/jump instruction is jumping back to itself,
USE_ALL_CYCLES should not set m68ki_remaining_cycles to zero, because
that optimization reports more cycles spent than would have been
consumed without the optimization. If the jump takes N cycles, and
m68ki_remaining_cycles is not an multiple of N, then we want to spend
just a multiple of N and leave the remainder (m68ki_remaining_cycles % N
cycles). Setting to zero spends extra cycles corresponding to the
remainder.

After executing the jump, m68k_execute will then deduct N from
m68ki_remaining_cycles, consuming the remaining cycles (and some) ending
the execution loop, returning initial_cycles - remaining_cycles as
consumed.

When spending the remainder, what's effectively being returned as
consumed is initial_cycles + N, instead of initial_cycles - remainder +
N.

What we saw, when single-stepping with m68k_execute(1) was 1 + 8 = 9 cycles for a AI-
jump for example, instead of 1 - 1 + 8 = 8.
