### PR TITLE
Fix MOVEM cycle-counts

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -692,17 +692,17 @@ move      32  tou   .     0100111001100...  ..........  S S S    4   6   2
 movec     32  cr    .     0100111001111010  ..........  . S S    .  12   6
 movec     32  rc    .     0100111001111011  ..........  . S S    .  10  12
 movem     16  re    pd    0100100010100...  ..........  U U U    8   8   4
-movem     16  re    .     0100100010......  A..DXWL...  U U U    4   4   4  cycles for hypotetical d addressing mode
+movem     16  re    .     0100100010......  A..DXWL...  U U U    4   4   4  cycles for hypothetical d addressing mode (020 unverified)
 movem     32  re    pd    0100100011100...  ..........  U U U    8   8   4
-movem     32  re    .     0100100011......  A..DXWL...  U U U    0   0   4  cycles for hypotetical d addressing mode
+movem     32  re    .     0100100011......  A..DXWL...  U U U    0   0   4  cycles for hypothetical d addressing mode (020 unverified)
 movem     16  er    pi    0100110010011...  ..........  U U U   12  12   8
 movem     16  er    pcdi  0100110010111010  ..........  U U U   16  16   9
 movem     16  er    pcix  0100110010111011  ..........  U U U   18  18  11
-movem     16  er    .     0100110010......  A..DXWL...  U U U    8   8   8  cycles for hypotetical d addressing mode
+movem     16  er    .     0100110010......  A..DXWL...  U U U    8   8   8  cycles for hypothetical d addressing mode (020 unverified)
 movem     32  er    pi    0100110011011...  ..........  U U U   12  12   8
 movem     32  er    pcdi  0100110011111010  ..........  U U U   16  16   9
 movem     32  er    pcix  0100110011111011  ..........  U U U   18  18  11
-movem     32  er    .     0100110011......  A..DXWL...  U U U    4   4   8  cycles for hypotetical d addressing mode
+movem     32  er    .     0100110011......  A..DXWL...  U U U    4   4   8  cycles for hypothetical d addressing mode (020 unverified)
 movep     16  er    .     0000...100001...  ..........  U U U   16  16  12
 movep     32  er    .     0000...101001...  ..........  U U U   24  24  18
 movep     16  re    .     0000...110001...  ..........  U U U   16  16  11

--- a/m68k_in.c
+++ b/m68k_in.c
@@ -692,17 +692,17 @@ move      32  tou   .     0100111001100...  ..........  S S S    4   6   2
 movec     32  cr    .     0100111001111010  ..........  . S S    .  12   6
 movec     32  rc    .     0100111001111011  ..........  . S S    .  10  12
 movem     16  re    pd    0100100010100...  ..........  U U U    8   8   4
-movem     16  re    .     0100100010......  A..DXWL...  U U U    8   8   4
+movem     16  re    .     0100100010......  A..DXWL...  U U U    4   4   4  cycles for hypotetical d addressing mode
 movem     32  re    pd    0100100011100...  ..........  U U U    8   8   4
-movem     32  re    .     0100100011......  A..DXWL...  U U U    8   8   4
+movem     32  re    .     0100100011......  A..DXWL...  U U U    0   0   4  cycles for hypotetical d addressing mode
 movem     16  er    pi    0100110010011...  ..........  U U U   12  12   8
 movem     16  er    pcdi  0100110010111010  ..........  U U U   16  16   9
 movem     16  er    pcix  0100110010111011  ..........  U U U   18  18  11
-movem     16  er    .     0100110010......  A..DXWL...  U U U   12  12   8
+movem     16  er    .     0100110010......  A..DXWL...  U U U    8   8   8  cycles for hypotetical d addressing mode
 movem     32  er    pi    0100110011011...  ..........  U U U   12  12   8
-movem     32  er    pcdi  0100110011111010  ..........  U U U   20  20   9
-movem     32  er    pcix  0100110011111011  ..........  U U U   22  22  11
-movem     32  er    .     0100110011......  A..DXWL...  U U U   12  12   8
+movem     32  er    pcdi  0100110011111010  ..........  U U U   16  16   9
+movem     32  er    pcix  0100110011111011  ..........  U U U   18  18  11
+movem     32  er    .     0100110011......  A..DXWL...  U U U    4   4   8  cycles for hypotetical d addressing mode
 movep     16  er    .     0000...100001...  ..........  U U U   16  16  12
 movep     32  er    .     0000...101001...  ..........  U U U   24  24  18
 movep     16  re    .     0000...110001...  ..........  U U U   16  16  11


### PR DESCRIPTION
This PR fixes MOVEM cycle counts for all 16/32-bit addressing modes for the 000 and 010, except pi, pd, and 16-bit pcdi/pcix which were already correct, as they require separate implementations and were listed separately. 

Previously most addressing modes used 4 (16-bit) or 8 (32-bit) cycles too much. 32-bit pcdi/pcix was off by 4. 

The explanation for this is likely that cycle counts in m68k_in.c are representative for the minimum An/Dn base case, and additional addressing mode cycle costs are added elsewhere per mode to get cycles for a particular instruction and a particular addressing mode.

But no An/Dn base case is available for MOVEM, so the data were likely from the "address indirect" mode, causing an additional cost of 4 or 8 cycles for all addressing modes in the "." case in the table.

So we now fill the table with the cycles for a hypothetical register base case not present for MOVEM, in order to end up with the correct calculated cycles for the existing addressing modes. (This looks really odd on line 697 where the hypothetical register base case is zero cycles.)

Resulting cycles verified against (r68k implementation of) MC68000UM
counts for MOVEM taken from Table 8-10. JMP, JSR, LEA, PEA, and MOVEM Instruction Execution Times. 68010 cycles have been verified against Table 9-16. JMP, JSR, LEA, PEA, and MOVEM Instruction Execution Times and they are all the same as on the 000 ...

## One oddity though
Except for the fact that MOVEM_32_ER_AI is listed as a 24+8n cycles on the 68010 (according to MC68000UM (or _M68000 8-/16-/32-Bit Microprocessors User’s Manual, Ninth Edition_), which is _twice_ the number of cycles of the corresponding 68000 instruction variant, and the only MOVEM-variant where 010 and 000 differs, as well as the only MOVEM addressing mode where Word and Long cycles differ. I'm thinking it must be a typo, and the correct formula should be 12+8n, and that's what this PR uses.

## Also 020 is left dangling
Note that 020 cycles have not been verified (or changed)! There's also no comments stating that - which makes the table look a bit odd, come to think of it, where it now looks like 020 is slower than 000/010 in some cases. 

Let me know if this is a problem.