### PR TITLE
Fix pea_32_ai cycles

### DIFF
--- a/m68kmake.c
+++ b/m68kmake.c
@@ -395,7 +395,7 @@ int g_lea_cycle_table[13] =
 int g_pea_cycle_table[13] =
 {
 	 0, /* EA_MODE_NONE */
-	 4, /* EA_MODE_AI   */
+	 6, /* EA_MODE_AI   */
 	 0, /* EA_MODE_PI   */
 	 0, /* EA_MODE_PI7  */
 	 0, /* EA_MODE_PD   */


### PR DESCRIPTION
This PR adjusts the AI mode of PEA to use 12 cycles instead of 10, for the 68000 and 010.

According to MC68000UM, the AI mode of PEA uses 12 cycles (not 10) on the
68000 (see Table 8-10) and 010 (see Table 9-16). The base case in the
handler table is 6 cycles, so 6 additional cycles is needed to end up
with 12. The adjustments for the other addressing modes were correct.