### PR TITLE
Make STOP properly consume all cycles

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -9252,7 +9252,10 @@ M68KMAKE_OP(stop, 0, ., .)
 		m68ki_trace_t0();			   /* auto-disable (see m68kcpu.h) */
 		CPU_STOPPED |= STOP_LEVEL_STOP;
 		m68ki_set_sr(new_sr);
-		m68ki_remaining_cycles = 0;
+		if(m68ki_remaining_cycles >= CYC_INSTRUCTION[REG_IR])
+			m68ki_remaining_cycles = CYC_INSTRUCTION[REG_IR];
+		else
+			USE_ALL_CYCLES();
 		return;
 	}
 	m68ki_exception_privilege_violation();


### PR DESCRIPTION
Much like #16 this PR is about not overspending cycles. However it's a bit more complicated in the case of STOP, which should (in supervisor mode) consume at least 4 cycles, but just consume any excess cycles if given more - as the processor enters the stopped state after 4 cycles. 

Given 1-4 cycles to execute a STOP, will consume 4 cycles (the cost of the stop instruction).
Given more than 4 cycles to execute a STOP, will consume all given cycles.
 
Just using USE_ALL_CYCLES() would (after #16) always consume multiples of 4, which doesn't seem right, as the processor is no longer executing any instructions after a successful STOP.

Without this PR, a STOP consumes all given cycles _plus_ 4 for the STOP - for example, given 6 cycles would consume 10.