### PR TITLE
Fix address error cycle count and cycle depletion behavior

### DIFF
--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -523,6 +523,13 @@
 				CPU_INT_CYCLES = 0; \
 				return m68ki_initial_cycles; \
 			} \
+			/* ensure we don't re-enter execution loop after an
+			   address error if there's no more cycles remaining */ \
+			if(GET_CYCLES() <= 0) \
+			{ \
+				/* return how many clocks we used */ \
+				return m68ki_initial_cycles - GET_CYCLES(); \
+			} \
 		}
 
 	#define m68ki_check_address_error(ADDR, WRITE_MODE, FC) \

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -1881,8 +1881,11 @@ m68k_read_memory_8(0x00ffff01);
 
 	m68ki_jump_vector(EXCEPTION_ADDRESS_ERROR);
 
-	/* Use up some clock cycles and undo the instruction's cycles */
-	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_ADDRESS_ERROR] - CYC_INSTRUCTION[REG_IR]);
+	/* Use up some clock cycles. Note that we don't need to undo the 
+	instruction's cycles here as we've longjmp:ed directly from the
+	instruction handler without passing the part of the excecute loop
+	that deducts instruction cycles */
+	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_ADDRESS_ERROR]); 
 }
 
 


### PR DESCRIPTION
This PR fixes a cycle count issue during address errors, and if the address error depletes all remaining cycles, now returns from execution without executing further instructions.

### Cycle count
The address error handler is called after a longjmp that does not pass the part of the excecute loop that deducts instruction cycles. This means we should not try to undo the instruction's cycles, as other exception handlers do, because this will incorrectly reduce the cost of the exception by the number of cycles for the current instruction.

For costly instructions like MUL and DIV, this will in effect result in a _net increase_ of available cycles. This could, I guess, result in an situation where available cycles for m68k_execute never runs out:

* an address error occurs during an expensive instruction, which will in effect add more cycles to the budget
* the exception handler is cheap and basically just does RTE
* back to normal run mode, and the faulting instruction, that causes another address error

### Depletion behavior
Even if an address error depletes all remaining cycles, control would still re-enter the execution loop (as the longjmp that initiates address-error handling returns control to just above the `do-while(remaining cycles)` loop) and would then execute at least one instruction of the address-error exception handler, before noticing that no more cycles remained.

This is different from the other (non-longjmping) exception handlers, as they are executed as part of the normal instruction handler, which returns normally to within the execution loop, that then checks the loop condition for available cycles before executing another instruction.

It might have reduced duplication to change the `do-while(remaining cycles)` loop to a `while(remaining cycles)` loop, but that would have changed the semantics of client programs "single-stepping" m68k_execute with zero or negative num_cycles.