### PR TITLE
Undo instruction cycles in trap exception

### DIFF
--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -1725,8 +1725,8 @@ INLINE void m68ki_exception_trap(uint vector)
 
 	m68ki_jump_vector(vector);
 
-	/* Use up some clock cycles */
-	USE_CYCLES(CYC_EXCEPTION[vector]);
+	/* Use up some clock cycles and undo the instruction's cycles */
+	USE_CYCLES(CYC_EXCEPTION[vector] - CYC_INSTRUCTION[REG_IR]);
 }
 
 /* Trap#n stacks a 0 frame but behaves like group2 otherwise */


### PR DESCRIPTION
As trap exceptions are called from within a normal instruction handler
(as opposed to the address error handler that are called via a longjmp),
control will eventually return to the execution loop where the
instructions cycles will be deducted.

This PR adds the cycles for the instructions back to the available
cycles, or we will pay both the cost of the exception, and of the
instruction.