### PR TITLE
Undo instruction cycles in trap#n exception

### DIFF
--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -1736,8 +1736,8 @@ INLINE void m68ki_exception_trapN(uint vector)
 	m68ki_stack_frame_0000(REG_PC, sr, vector);
 	m68ki_jump_vector(vector);
 
-	/* Use up some clock cycles */
-	USE_CYCLES(CYC_EXCEPTION[vector]);
+	/* Use up some clock cycles and undo the instruction's cycles */
+	USE_CYCLES(CYC_EXCEPTION[vector] - CYC_INSTRUCTION[REG_IR]);
 }
 
 /* Exception for trace mode */


### PR DESCRIPTION
This PR looks very similar but deals with trap#n exceptions ;)

As trap#n exceptions are called from within a normal instruction handler
(as opposed to the address error handler that are called via a longjmp),
control will eventually return to the execution loop where the
instructions cycles will be deducted.

This PR adds the cycles for the instructions back to the available
cycles, or we will pay both the cost of the exception, and of the
instruction.