### PR TITLE
Fix unimplemented instruction cycles

### DIFF
--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -129,8 +129,8 @@ uint8 m68ki_exception_cycle_table[3][256] =
 		 34, /*  7: TRAPV                                              */
 		 34, /*  8: Privilege Violation                                */
 		 34, /*  9: Trace                                              */
-		  4, /* 10: 1010                                               */
-		  4, /* 11: 1111                                               */
+		 34, /* 10: 1010                                               */
+		 34, /* 11: 1111                                               */
 		  4, /* 12: RESERVED                                           */
 		  4, /* 13: Coprocessor Protocol Violation        (unemulated) */
 		  4, /* 14: Format Error                                       */


### PR DESCRIPTION
According to the M68000UM, the two unimplemented instruction exceptions
both cost 34 cycles, not 4.

Actually, that's a bit of a lie. Table 8-14. Exception Processing
Execution Times does not even mention unimplemented instruction
exceptions, but section 6.3.6 Illegal and Unimplemented Instructions
basically says that unimplemented instructions are just a special case
of illegal instructions in that they have separate exception vectors.