### PR TITLE
Remove extra `#include <stdio.h>` to fix `uint`

### DIFF
--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -562,7 +562,6 @@ void m68k_set_instr_hook_callback(void  (*callback)(void))
 	CALLBACK_INSTR_HOOK = callback ? callback : default_instr_hook_callback;
 }
 
-#include <stdio.h>
 /* Set the CPU type. */
 void m68k_set_cpu_type(unsigned int cpu_type)
 {


### PR DESCRIPTION
There was a conflict between Musahi's uint and OpenBSD's uint:

    $ cc -o m68kmake m68kmake.c
    $ ./m68kmake
    $ cc -DM68K_COMPILE_FOR_MAME=0 -c m68kcpu.c
    In file included from m68kcpu.c:565:
    In file included from /usr/include/stdio.h:46:
    /usr/include/sys/types.h:58:22: error: cannot combine with previous 'int'
          declaration specifier
    typedef unsigned int    uint;           /* Sys V compatibility */
                            ^
    ./m68kcpu.h:75:25: note: expanded from macro 'uint'
    #define uint   unsigned int
                            ^
    1 error generated.