### PR TITLE
Fix loop condition

### DIFF
--- a/m68kmake.c
+++ b/m68kmake.c
@@ -649,7 +649,7 @@ opcode_struct* find_opcode(char* name, int size, char* spec_proc, char* spec_ea)
 	opcode_struct* op;
 
 
-	for(op = g_opcode_input_table;op->name != NULL;op++)
+	for(op = g_opcode_input_table;op < &g_opcode_input_table[MAX_OPCODE_INPUT_TABLE_LENGTH];op++)
 	{
 		if(	strcmp(name, op->name) == 0 &&
 			(size == op->size) &&
@@ -665,7 +665,7 @@ opcode_struct* find_illegal_opcode(void)
 {
 	opcode_struct* op;
 
-	for(op = g_opcode_input_table;op->name != NULL;op++)
+	for(op = g_opcode_input_table;op < &g_opcode_input_table[MAX_OPCODE_INPUT_TABLE_LENGTH];op++)
 	{
 		if(strcmp(op->name, "illegal") == 0)
 			return op;


### PR DESCRIPTION
`name` field in `struct opcode_struct` is an array,
so the condition is always false.

gcc warns:

```sh
$ gcc -o m68kmake -I. -Wall -Werror -DM68K_COMPILE_FOR_MAME=0 m68kmake.c
m68kmake.c:652:36: error: comparison of array 'op->name' not equal to a null pointer is always true [-Werror,-Wtautological-pointer-compare]
        for(op = g_opcode_input_table;op->name != NULL;op++)
                                      ~~~~^~~~    ~~~~
m68kmake.c:668:36: error: comparison of array 'op->name' not equal to a null pointer is always true [-Werror,-Wtautological-pointer-compare]
        for(op = g_opcode_input_table;op->name != NULL;op++)
                                      ~~~~^~~~    ~~~~
2 errors generated.
```

This change fixes potential error which accessing out of range.
