### PR TITLE
Illegal instruction callback

### DIFF
--- a/m68k.h
+++ b/m68k.h
@@ -256,7 +256,13 @@ void m68k_set_pc_changed_callback(void  (*callback)(unsigned int new_pc));
  */
 void m68k_set_tas_instr_callback(int  (*callback)(void));
 
-
+/* Set the callback for illegal instructions.
+ * You must enable M68K_ILLG_HAS_CALLBACK in m68kconf.h.
+ * The CPU calls this callback every time it encounters an illegal instruction
+ * which must return 1 if it handles the instruction normally or 0 if it's really an illegal instruction.
+ * Default behavior: return 0, exception will occur.
+ */
+void m68k_set_illg_instr_callback(int  (*callback)(int));
 
 /* Set the callback for CPU function code changes.
  * You must enable M68K_EMULATE_FC in m68kconf.h.

--- a/m68kconf.h
+++ b/m68kconf.h
@@ -129,6 +129,17 @@
 #define M68K_TAS_HAS_CALLBACK       OPT_OFF
 #define M68K_TAS_CALLBACK()         your_tas_handler_function()
 
+/* If ON, CPU will call the callback when it encounters an illegal instruction
+ * passing the opcode as argument. If the callback returns 1, then it's considered
+ * as a normal instruction, and the illegal exception in canceled. If it returns 0,
+ * the exception occurs normally.
+ * The callback looks like int callback(int opcode)
+ * You should put OPT_SPECIFY_HANDLER here if you cant to use it, otherwise it will
+ * use a dummy default handler and you'll have to call m68k_set_illg_instr_callback explicitely
+ */
+#define M68K_ILLG_HAS_CALLBACK	    OPT_OFF
+#define M68K_ILLG_CALLBACK(opcode)  op_illg(opcode)
+
 /* If ON, CPU will call the set fc callback on every memory access to
  * differentiate between user/supervisor, program/data access like a real
  * 68000 would.  This should be enabled and the callback should be set if you

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -486,6 +486,12 @@ static int default_tas_instr_callback(void)
 	return 1; // allow writeback
 }
 
+/* Called when an illegal instruction is encountered */
+static int default_illg_instr_callback(int opcode)
+{
+	return 0; // not handled : exception will occur
+}
+
 /* Called when the program counter changed by a large value */
 static unsigned int default_pc_changed_callback_data;
 static void default_pc_changed_callback(unsigned int new_pc)
@@ -657,6 +663,11 @@ void m68k_set_rte_instr_callback(void  (*callback)(void))
 void m68k_set_tas_instr_callback(int  (*callback)(void))
 {
 	CALLBACK_TAS_INSTR = callback ? callback : default_tas_instr_callback;
+}
+
+void m68k_set_illg_instr_callback(int  (*callback)(int))
+{
+	CALLBACK_ILLG_INSTR = callback ? callback : default_illg_instr_callback;
 }
 
 void m68k_set_pc_changed_callback(void  (*callback)(unsigned int new_pc))
@@ -893,6 +904,7 @@ void m68k_init(void)
 	m68k_set_cmpild_instr_callback(NULL);
 	m68k_set_rte_instr_callback(NULL);
 	m68k_set_tas_instr_callback(NULL);
+	m68k_set_illg_instr_callback(NULL);
 	m68k_set_pc_changed_callback(NULL);
 	m68k_set_fc_callback(NULL);
 	m68k_set_instr_hook_callback(NULL);

--- a/m68kfpu.c
+++ b/m68kfpu.c
@@ -406,12 +406,12 @@ static fp_reg READ_EA_FPE(int ea)
 	{
 		case 3:		// (An)+
 		{
-			uint32 d1,d2,d3;
+			uint32 d1,d2;
 			uint32 ea = REG_A[reg];
 			REG_A[reg] += 12;
 			d1 = m68ki_read_32(ea+0);
 			d2 = m68ki_read_32(ea+4);
-			d3 = m68ki_read_32(ea+8);
+			// d3 = m68ki_read_32(ea+8);
 			r.i = (uint64)(d1) << 32 | (uint64)(d2);
 			break;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -11,8 +11,9 @@
 INTRODUCTION:
 ------------
 
-Musashi is a Motorola 68000, 68010, 68EC020, and 68020 emulator written in C.
-This emulator was written with two goals in mind: portability and speed.
+Musashi is a Motorola 68000, 68010, 68EC020, 68020 and 68040 emulator written
+in C.  This emulator was written with two goals in mind: portability and
+speed.
 
 The emulator is written to ANSI C89 specifications.  It also uses inline
 functions, which are C9X compliant.
@@ -302,4 +303,15 @@ of the CPU.
 EXAMPLE:
 -------
 
-The subdir example contains a full example (currently DOS only).
+The subdir example contains a full example (currently linux & Dos only).
+
+Compilation
+-----------
+
+You can use the default Makefile in Musashi's directory, it works like this :
+1st build m68kmake, which will build m68kops.c and m68kops.h based on the
+contents of m68k_in.c.
+Then compile m68kcpu.o and m68kops.o. Add m68kdasm.o if you want the
+disassemble functions. When linking this to your project you will need libm
+for the fpu emulation of the 68040.
+


### PR DESCRIPTION
Hi ! Long time no see... !
Anyway it's about the illegal instruction callback I talked about.
The idea behind this is to be able to use the musashi files in a project and modify only m68kconf.h, otherwise it would be much faster to modify only m68kcpu.h for this (what I did last night).
The patch adds a ton of comment in m68kconf.h about that, I tested the 3 cases, the one with OPT_ON without wanting to actually... but anyway it works. As I said in the comment you should always put OPT_SPECIFY_HANDLER if you want to use it, it declares the handler as extern in this case to avoid a compilation error.