### PR TITLE
fixed disassembly (completely broken in !g_rawop mode )

### DIFF
--- a/m68kdasm.c
+++ b/m68kdasm.c
@@ -270,7 +270,7 @@ static uint dasm_read_imm_16(uint advance)
 		result = (g_rawop[g_cpu_pc + 0 - g_rawbasepc] << 8) |
 		          g_rawop[g_cpu_pc + 1 - g_rawbasepc];
 	else
-		result = m68k_read_disassembler_16(g_cpu_pc & g_address_mask) & 0xff;
+		result = m68k_read_disassembler_16(g_cpu_pc & g_address_mask) & 0xffff;
 	g_cpu_pc += advance;
 	return result;
 }
@@ -284,7 +284,7 @@ static uint dasm_read_imm_32(uint advance)
 		         (g_rawop[g_cpu_pc + 2 - g_rawbasepc] << 8) |
 		          g_rawop[g_cpu_pc + 3 - g_rawbasepc];
 	else
-		result = m68k_read_disassembler_32(g_cpu_pc & g_address_mask) & 0xff;
+		result = m68k_read_disassembler_32(g_cpu_pc & g_address_mask) & 0xffffffff;
 	g_cpu_pc += advance;
 	return result;
 }


### PR DESCRIPTION
when using read immediate mode for disassembly ( ie using m68k_read_disassembler_16 & co ), the disassembly is totally broken because of typo. Only 8bits of opcode is read instead of 16 or 32bits