### PR TITLE
allow to set the config file from a define

### DIFF
--- a/example/m68kconf.h
+++ b/example/m68kconf.h
@@ -199,16 +199,16 @@
 
 #include "sim.h"
 
-#define m68k_read_memory_8(A) cpu_read_byte(A)
-#define m68k_read_memory_16(A) cpu_read_word(A)
-#define m68k_read_memory_32(A) cpu_read_long(A)
+#define m68k_read_memory_8 cpu_read_byte
+#define m68k_read_memory_16 cpu_read_word
+#define m68k_read_memory_32 cpu_read_long
 
 #define m68k_read_disassembler_16(A) cpu_read_word_dasm(A)
 #define m68k_read_disassembler_32(A) cpu_read_long_dasm(A)
 
-#define m68k_write_memory_8(A, V) cpu_write_byte(A, V)
-#define m68k_write_memory_16(A, V) cpu_write_word(A, V)
-#define m68k_write_memory_32(A, V) cpu_write_long(A, V)
+#define m68k_write_memory_8 cpu_write_byte
+#define m68k_write_memory_16 cpu_write_word
+#define m68k_write_memory_32 cpu_write_long
 
 
 #endif /* M68K_COMPILE_FOR_MAME */

--- a/m68k.h
+++ b/m68k.h
@@ -48,8 +48,11 @@ extern "C" {
 /* ======================================================================== */
 
 /* Import the configuration for this build */
+#ifdef MUSASHI_CNF
+#include MUSASHI_CNF
+#else
 #include "m68kconf.h"
-
+#endif
 
 /* ======================================================================== */
 /* ============================ GENERAL DEFINES =========================== */

--- a/m68kconf.h
+++ b/m68kconf.h
@@ -74,7 +74,7 @@
  * and m68k_read_pcrelative_xx() for PC-relative addressing.
  * If off, all read requests from the CPU will be redirected to m68k_read_xx()
  */
-#define M68K_SEPARATE_READS         OPT_OFF
+#define M68K_SEPARATE_READS         OPT_ON
 
 /* If ON, the CPU will call m68k_write_32_pd() when it executes move.l with a
  * predecrement destination EA mode instead of m68k_write_32().

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -911,6 +911,23 @@ void m68k_init(void)
 	m68k_set_pc_changed_callback(NULL);
 	m68k_set_fc_callback(NULL);
 	m68k_set_instr_hook_callback(NULL);
+	m68ki_cpu.read8 = m68k_read_memory_8;
+	m68ki_cpu.read16 = m68k_read_memory_16;
+	m68ki_cpu.read32 = m68k_read_memory_32;
+	m68ki_cpu.write8 = m68k_write_memory_8;
+	m68ki_cpu.write16 = m68k_write_memory_16;
+	m68ki_cpu.write32 = m68k_write_memory_32;
+#if M68K_SEPARATE_READS
+	// Notice : you need to overwrite these if you use them, these are default values
+	// when the reads are actually not separated.
+	// I initialize this because otherwise if M68K_SEPARATE_READS is defined then the
+	// calls would end here, and if uninitialized it would just crash on null pointer.
+	m68ki_cpu.read_im16 = m68k_read_memory_16;
+	m68ki_cpu.read_im32 = m68k_read_memory_32;
+	m68ki_cpu.read_pc8 = m68k_read_memory_8;
+	m68ki_cpu.read_pc16 = m68k_read_memory_16;
+	m68ki_cpu.read_pc32 = m68k_read_memory_32;
+#endif
 }
 
 /* Pulse the RESET line on the CPU */

--- a/readme.txt
+++ b/readme.txt
@@ -318,3 +318,13 @@ Then compile m68kcpu.o and m68kops.o. Add m68kdasm.o if you want the
 disassemble functions. When linking this to your project you will need libm
 for the fpu emulation of the 68040.
 
+Using some custom m68kconf.h outside Musashi's directory
+--------------------------------------------------------
+
+It can be useful to keep an untouched musashi directory in a project (from
+git for example) and maintain a separate m68kconf.h specific to the
+project. For this, pass -DMUSASHI_CNF="mycustomconfig.h" to gcc (or whatever
+compiler you use). Notice that if you use an unix shell (or make which uses
+the shell to launch its commands), then you need to escape the quotes like
+this : -DMUSASHI_CNF=\"mycustomconfig.h\"
+

--- a/readme.txt
+++ b/readme.txt
@@ -141,11 +141,14 @@ fetching from ROM or RAM.  Immediate reads are always from the program space
 
 To enable separate immediate reads:
 
-- In m68kconf.h, turn on M68K_SEPARATE_READ_IMM.
+- In m68kconf.h, turn on M68K_SEPARATE_READS.
 
-- In your host program, implement the following functions:
-    unsigned int  m68k_read_immediate_16(unsigned int address);
-    unsigned int  m68k_read_immediate_32(unsigned int address);
+- In your host program, assign those in m68ki_cpu :
+	read_im16
+	read_im32 for immediate reads
+	read_pc8
+	read_pc16
+	read_pc32 for pc relative reads
 
 - If you need to know the current PC (for banking and such), set
   M68K_MONITOR_PC to OPT_SPECIFY_HANDLER, and set M68K_SET_PC_CALLBACK(A) to


### PR DESCRIPTION
warning the quotes must be escaped :
gcc -DMUSASHI_CNF=\"myconf.h\" ...

It's to allow to include musashi as a git submodule in a project. This allows you to change you config file as you want while keeping the project's makefile separated.
If you don't pass any MUSASHI_CNF define then of course the default config file is included.