### PR TITLE
Use memmove instead of memcpy when the buffer pointers overlap

### DIFF
--- a/m68kmake.c
+++ b/m68kmake.c
@@ -593,7 +593,7 @@ int fgetline(char* buff, int nchars, FILE* file)
 	if(fgets(buff, nchars, file) == NULL)
 		return -1;
 	if(buff[0] == '\r')
-		memcpy(buff, buff + 1, nchars - 1);
+		memmove(buff, buff + 1, nchars - 1);
 
 	length = strlen(buff);
 	while(length && (buff[length-1] == '\r' || buff[length-1] == '\n'))


### PR DESCRIPTION
On some architectures, memcpy uses optimisations which break when the
buffer pointers overlap. Where buffers overlap, memmove should be used
instead.