### PR TITLE
Add bus error emulation support

### DIFF
--- a/m68k.h
+++ b/m68k.h
@@ -341,6 +341,10 @@ unsigned int m68k_get_virq(unsigned int level);
 void m68k_pulse_halt(void);
 
 
+/* Trigger a bus error exception */
+void m68k_pulse_bus_error(void);
+
+
 /* Context switching to allow multiple CPUs */
 
 /* Get the size of the cpu context in bytes */

--- a/m68k_in.c
+++ b/m68k_in.c
@@ -9212,10 +9212,36 @@ M68KMAKE_OP(rte, 32, ., .)
 				CPU_INSTR_MODE = INSTRUCTION_YES;
 				CPU_RUN_MODE = RUN_MODE_NORMAL;
 				return;
+			} else if (format_word == 8) {
+				/* Format 8 stack frame -- 68010 only. 29 word bus/address error */
+				new_sr = m68ki_pull_16();
+				new_pc = m68ki_pull_32();
+				m68ki_fake_pull_16();	/* format word */
+				m68ki_fake_pull_16();	/* special status word */
+				m68ki_fake_pull_32();	/* fault address */
+				m68ki_fake_pull_16();	/* unused/reserved */
+				m68ki_fake_pull_16();	/* data output buffer */
+				m68ki_fake_pull_16();	/* unused/reserved */
+				m68ki_fake_pull_16();	/* data input buffer */
+				m68ki_fake_pull_16();	/* unused/reserved */
+				m68ki_fake_pull_16();	/* instruction input buffer */
+				m68ki_fake_pull_32();	/* internal information, 16 words */
+				m68ki_fake_pull_32();	/* (actually, we use 8 DWORDs) */
+				m68ki_fake_pull_32();
+				m68ki_fake_pull_32();
+				m68ki_fake_pull_32();
+				m68ki_fake_pull_32();
+				m68ki_fake_pull_32();
+				m68ki_fake_pull_32();
+				m68ki_jump(new_pc);
+				m68ki_set_sr(new_sr);
+				CPU_INSTR_MODE = INSTRUCTION_YES;
+				CPU_RUN_MODE = RUN_MODE_NORMAL;
+				return;
 			}
 			CPU_INSTR_MODE = INSTRUCTION_YES;
 			CPU_RUN_MODE = RUN_MODE_NORMAL;
-			/* Not handling bus fault (9) */
+			/* Not handling other exception types (9) */
 			m68ki_exception_format_error();
 			return;
 		}

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -800,6 +800,7 @@ int m68k_execute(int num_cycles)
 		/* Main loop.  Keep going until we run out of clock cycles */
 		do
 		{
+			int i;
 			/* Set tracing accodring to T1. (T0 is done inside instruction) */
 			m68ki_trace_t1(); /* auto-disable (see m68kcpu.h) */
 

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -81,6 +81,8 @@ jmp_buf m68ki_aerr_trap;
 uint    m68ki_aerr_address;
 uint    m68ki_aerr_write_mode;
 uint    m68ki_aerr_fc;
+jmp_buf m68ki_bus_error_jmp_buf;
+jmp_buf m68ki_bus_error_return_jmp_buf;
 
 /* Used by shift & rotate instructions */
 const uint8 m68ki_shift_8_table[65] =
@@ -793,6 +795,8 @@ int m68k_execute(int num_cycles)
 		/* Return point if we had an address error */
 		m68ki_set_address_error_trap(); /* auto-disable (see m68kcpu.h) */
 
+		m68ki_check_bus_error_trap();
+
 		/* Main loop.  Keep going until we run out of clock cycles */
 		do
 		{
@@ -807,6 +811,11 @@ int m68k_execute(int num_cycles)
 
 			/* Record previous program counter */
 			REG_PPC = REG_PC;
+
+			/* Record previous D/A register state (in case of bus error) */
+			for (i = 15; i >= 0; i--){
+				REG_DA_SAVE[i] = REG_DA[i];
+			}
 
 			/* Read an instruction and call its handler */
 			REG_IR = m68ki_read_imm_16();
@@ -911,6 +920,12 @@ void m68k_init(void)
 	m68k_set_pc_changed_callback(NULL);
 	m68k_set_fc_callback(NULL);
 	m68k_set_instr_hook_callback(NULL);
+}
+
+/* Trigger a Bus Error exception */
+void m68k_pulse_bus_error(void)
+{
+	m68ki_exception_bus_error();
 }
 
 /* Pulse the RESET line on the CPU */

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -81,8 +81,8 @@ jmp_buf m68ki_aerr_trap;
 uint    m68ki_aerr_address;
 uint    m68ki_aerr_write_mode;
 uint    m68ki_aerr_fc;
+
 jmp_buf m68ki_bus_error_jmp_buf;
-jmp_buf m68ki_bus_error_return_jmp_buf;
 
 /* Used by shift & rotate instructions */
 const uint8 m68ki_shift_8_table[65] =

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -40,9 +40,7 @@ extern "C" {
 #include "m68k.h"
 #include <limits.h>
 
-#if M68K_EMULATE_ADDRESS_ERROR
 #include <setjmp.h>
-#endif /* M68K_EMULATE_ADDRESS_ERROR */
 
 /* ======================================================================== */
 /* ==================== ARCHITECTURE-DEPENDANT DEFINES ==================== */

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -1793,7 +1793,6 @@ static inline void m68ki_exception_privilege_violation(void)
 }
 
 extern jmp_buf m68ki_bus_error_jmp_buf;
-extern jmp_buf m68ki_bus_error_return_jmp_buf;
 
 #define m68ki_check_bus_error_trap() setjmp(m68ki_bus_error_jmp_buf)
 


### PR DESCRIPTION
Pull in the bus error emulation support from philpem/freebee.

This might need a bit of clean-up work.

It's quite similar to address error emulation, except that the 68K (010 and later at least) allows instructions which cause bus-errors to be restarted after the fault is resolved. This is widely used for memory paging on e.g. the AT&T 3B1 / 7300 / UNIX PC.  (e.g. a bus error is raised due to an access to memory which isn't mapped/paged in -- the fault handler pages in the needed memory and returns, executing the instruction)