### PR TITLE
2 fixes for the previous patches

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -8451,13 +8451,12 @@ M68KMAKE_OP(pea, 32, ., .)
 
 M68KMAKE_OP(pflush, 32, ., .)
 {
-	if ((CPU_TYPE_IS_040_PLUS(CPU_TYPE)) && (HAS_PMMU))
+	if ((CPU_TYPE_IS_EC020_PLUS(CPU_TYPE)) && (HAS_PMMU))
 	{
-		// Nothing to do, unless address translation cache is emulated
 		fprintf(stderr,"680x0: unhandled PFLUSH\n");
 		return;
 	}
-	m68ki_exception_illegal();
+	m68ki_exception_1111();
 }
 
 M68KMAKE_OP(pmove, 32, ., .)
@@ -8465,16 +8464,16 @@ M68KMAKE_OP(pmove, 32, ., .)
 	uint16 modes;
 	uint32 ea;
 
-	modes = m68ki_read_imm_16();
-	ea = M68KMAKE_GET_EA_AY_32;
-
 	if ((CPU_TYPE_IS_EC020_PLUS(CPU_TYPE)) && (HAS_PMMU))
 	{
+		modes = m68ki_read_imm_16();
+		ea = M68KMAKE_GET_EA_AY_32;
+
 		fprintf(stderr,"680x0: unhandled PMOVE modes %x ea %x\n", modes, ea);
 	}
 	else
 	{
-		m68ki_exception_illegal();
+		m68ki_exception_1111();
 	}
 }
 

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -53,7 +53,6 @@ extern void m68ki_build_opcode_table(void);
 
 int  m68ki_initial_cycles;
 int  m68ki_remaining_cycles = 0;                     /* Number of clocks remaining */
-uint m68ki_reset_cycles;
 uint m68ki_tracing = 0;
 uint m68ki_address_space;
 
@@ -903,9 +902,9 @@ void m68k_set_cpu_type(unsigned int cpu_type)
 int m68k_execute(int num_cycles)
 {
 	/* eat up any reset cycles */
-	if (m68ki_reset_cycles) {
-	    int rc = m68ki_reset_cycles;
-	    m68ki_reset_cycles = 0;
+	if (RESET_CYCLES) {
+	    int rc = RESET_CYCLES;
+	    RESET_CYCLES = 0;
 	    num_cycles -= rc;
 	    if (num_cycles <= 0)
 		return rc;
@@ -1080,7 +1079,7 @@ void m68k_pulse_reset(void)
 
 	CPU_RUN_MODE = RUN_MODE_NORMAL;
 
-	m68ki_reset_cycles = CYC_EXCEPTION[EXCEPTION_RESET];
+	RESET_CYCLES = CYC_EXCEPTION[EXCEPTION_RESET];
 }
 
 /* Pulse the HALT line on the CPU */

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -369,6 +369,7 @@ extern "C" {
 #define CYC_SHIFT        m68ki_cpu.cyc_shift
 #define CYC_RESET        m68ki_cpu.cyc_reset
 #define HAS_PMMU	 m68ki_cpu.has_pmmu
+#define RESET_CYCLES	 m68ki_cpu.reset_cycles
 
 
 #define CALLBACK_INT_ACK     m68ki_cpu.int_ack_callback
@@ -944,6 +945,7 @@ typedef struct
 	uint instr_mode;   /* Stores whether we are in instruction mode or group 0/1 exception mode */
 	uint run_mode;     /* Stores whether we are processing a reset, bus error, address error, or something else */
 	int    has_pmmu;     /* Indicates if a PMMU available (yes on 030, 040, no on EC030) */
+	uint reset_cycles;
 
 	/* Clocks required for instructions / exceptions */
 	uint cyc_bcc_notake_b;
@@ -980,7 +982,6 @@ typedef struct
 
 extern m68ki_cpu_core m68ki_cpu;
 extern sint           m68ki_remaining_cycles;
-extern uint	      m68ki_reset_cycles;
 extern uint           m68ki_tracing;
 extern const uint8    m68ki_shift_8_table[];
 extern const uint16   m68ki_shift_16_table[];


### PR DESCRIPTION
The first from mame to call line f instead of illegal instruction on cpus without pmmu
and mine to move reset_cycles to the cpu context so that it survives a context switch.
