### PR TITLE
big fpu update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Just a basic makefile to quickly test that everyting is working, it just
 # compiles the .o and the generator
 
-MUSASHIFILES     = m68kcpu.c m68kdasm.c
+MUSASHIFILES     = m68kcpu.c m68kdasm.c softfloat/softfloat.c
 MUSASHIGENCFILES = m68kops.c
 MUSASHIGENHFILES = m68kops.h
 MUSASHIGENERATOR = m68kmake

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ all: $(.OFILES)
 clean:
 	rm -f $(DELETEFILES)
 
-m68kcpu.o: $(MUSASHIGENHFILES)
+m68kcpu.o: $(MUSASHIGENHFILES) m68kfpu.c m68kmmu.h softfloat/softfloat.c softfloat/softfloat.h
 
 $(MUSASHIGENCFILES) $(MUSASHIGENHFILES): $(MUSASHIGENERATOR)$(EXE)
 	$(EXEPATH)$(MUSASHIGENERATOR)$(EXE)

--- a/example/Makefile
+++ b/example/Makefile
@@ -4,7 +4,7 @@ OSD_DOS          = osd_dos.c
 
 OSDFILES         = osd_linux.c # $(OSD_DOS)
 MAINFILES        = sim.c
-MUSASHIFILES     = m68kcpu.c m68kdasm.c
+MUSASHIFILES     = m68kcpu.c m68kdasm.c softfloat/softfloat.c
 MUSASHIGENCFILES = m68kops.c
 MUSASHIGENHFILES = m68kops.h
 MUSASHIGENERATOR = m68kmake

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -3,7 +3,7 @@
 /* ======================================================================== */
 /*
  *                                  MUSASHI
- *                                Version 4.55
+ *                                Version 4.60
  *
  * A portable Motorola M680x0 processor emulation engine.
  * Copyright Karl Stenerud.  All rights reserved.

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -38,6 +38,7 @@ extern "C" {
 #endif
 
 #include "m68k.h"
+
 #include <limits.h>
 
 #if M68K_EMULATE_ADDRESS_ERROR
@@ -67,26 +68,28 @@ extern "C" {
 #undef sint
 #undef uint
 
-#define sint8  signed   char			/* ASG: changed from char to signed char */
-#define sint16 signed   short
-#define sint32 signed   int			/* AWJ: changed from long to int */
-#define uint8  unsigned char
-#define uint16 unsigned short
-#define uint32 unsigned int			/* AWJ: changed from long to int */
+typedef signed   char  sint8;  		/* ASG: changed from char to signed char */
+typedef signed   short sint16;
+typedef signed   int   sint32; 		/* AWJ: changed from long to int */
+typedef unsigned char  uint8;
+typedef unsigned short uint16;
+typedef unsigned int   uint32; 			/* AWJ: changed from long to int */
 
 /* signed and unsigned int must be at least 32 bits wide */
-#define sint   signed   int
-#define uint   unsigned int
+typedef signed   int sint;
+typedef unsigned int uint;
 
 
 #if M68K_USE_64_BIT
-#define sint64 signed   long long
-#define uint64 unsigned long long
+typedef signed   long long sint64;
+typedef unsigned long long uint64;
 #else
-#define sint64 sint32
-#define uint64 uint32
+typedef sint32 sint64;
+typedef uint32 uint64;
 #endif /* M68K_USE_64_BIT */
 
+#include "softfloat/milieu.h"
+#include "softfloat/softfloat.h"
 
 
 /* Allow for architectures that don't have 8-bit sizes */
@@ -924,7 +927,7 @@ typedef struct
 	uint cacr;         /* Cache Control Register (m68020, unemulated) */
 	uint caar;         /* Cache Address Register (m68020, unemulated) */
 	uint ir;           /* Instruction Register */
-    fp_reg fpr[8];     /* FPU Data Register (m68040) */
+	floatx80 fpr[8];     /* FPU Data Register (m68030/040) */
 	uint fpiar;        /* FPU Instruction Address Register (m68040) */
 	uint fpsr;         /* FPU Status Register (m68040) */
 	uint fpcr;         /* FPU Control Register (m68040) */

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -960,6 +960,7 @@ typedef struct
 	uint run_mode;     /* Stores whether we are processing a reset, bus error, address error, or something else */
 	int    has_pmmu;     /* Indicates if a PMMU available (yes on 030, 040, no on EC030) */
 	int    pmmu_enabled; /* Indicates if the PMMU is enabled */
+	int    fpu_just_reset; /* Indicates the FPU was just reset */
 	uint reset_cycles;
 
 	/* Clocks required for instructions / exceptions */

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -88,6 +88,15 @@ typedef sint32 sint64;
 typedef uint32 uint64;
 #endif /* M68K_USE_64_BIT */
 
+/* U64 and S64 are used to wrap long integer constants. */
+#ifdef __GNUC__
+#define U64(val) val##ULL
+#define S64(val) val##LL
+#else
+#define U64(val) val
+#define S64(val) val
+#endif
+
 #include "softfloat/milieu.h"
 #include "softfloat/softfloat.h"
 

--- a/m68kdasm.c
+++ b/m68kdasm.c
@@ -499,7 +499,14 @@ static char* get_ea_mode_str(uint instruction, uint size)
 					strcat(mode, "[");
 				if(base)
 				{
-					strcat(mode, make_signed_hex_str_16(base));
+					if (EXT_BASE_DISPLACEMENT_LONG(extension))
+					{
+						strcat(mode, make_signed_hex_str_32(base));
+					}
+					else
+					{
+						strcat(mode, make_signed_hex_str_16(base));
+					}
 					comma = 1;
 				}
 				if(*base_reg)

--- a/m68kdasm.c
+++ b/m68kdasm.c
@@ -329,6 +329,11 @@ static uint dasm_read_imm_32(uint advance)
 #define get_imm_str_u16() get_imm_str_u(1)
 #define get_imm_str_u32() get_imm_str_u(2)
 
+static int sext_7bit_int(int value)
+{
+	return (value & 0x40) ? (value | 0xffffff80) : (value & 0x7f);
+}
+
 
 /* 100% portable signed int generators */
 static int make_int_8(int value)
@@ -1513,13 +1518,27 @@ static void d68020_cpgen(void)
 static void d68020_cprestore(void)
 {
 	LIMIT_CPU_TYPES(M68020_PLUS);
-	sprintf(g_dasm_str, "%drestore %s; (2-3)", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+	if (((g_cpu_ir>>9)&7) == 1)
+	{
+		sprintf(g_dasm_str, "frestore %s", get_ea_mode_str_8(g_cpu_ir));
+	}
+	else
+	{
+		sprintf(g_dasm_str, "%drestore %s; (2-3)", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+	}
 }
 
 static void d68020_cpsave(void)
 {
 	LIMIT_CPU_TYPES(M68020_PLUS);
-	sprintf(g_dasm_str, "%dsave   %s; (2-3)", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+	if (((g_cpu_ir>>9)&7) == 1)
+	{
+		sprintf(g_dasm_str, "fsave   %s", get_ea_mode_str_8(g_cpu_ir));
+	}
+	else
+	{
+		sprintf(g_dasm_str, "%dsave   %s; (2-3)", (g_cpu_ir>>9)&7, get_ea_mode_str_8(g_cpu_ir));
+	}
 }
 
 static void d68020_cpscc(void)
@@ -1698,11 +1717,7 @@ static void d68040_fpu(void)
 {
 	char float_data_format[8][3] =
 	{
-		".l", ".s", ".x", ".p", ".w", ".d", ".b", ".?"
-	};
-	const char *spec_reg[8] =
-	{
-		"?", "FPIAR", "FPSR", "?", "FPCR", "?", "?", "?"
+		".l", ".s", ".x", ".p", ".w", ".d", ".b", ".p"
 	};
 
 	char mnemonic[40];
@@ -1797,19 +1812,41 @@ static void d68040_fpu(void)
 
 		case 0x3:
 		{
-			sprintf(g_dasm_str, "fmove   FP%d, %s", dst_reg, get_ea_mode_str_32(g_cpu_ir));
+			switch ((w2>>10)&7)
+			{
+				case 3:		// packed decimal w/fixed k-factor
+					sprintf(g_dasm_str, "fmove%s   FP%d, %s {#%d}", float_data_format[(w2>>10)&7], dst_reg, get_ea_mode_str_32(g_cpu_ir), sext_7bit_int(w2&0x7f));
+					break;
+
+				case 7:		// packed decimal w/dynamic k-factor (register)
+					sprintf(g_dasm_str, "fmove%s   FP%d, %s {D%d}", float_data_format[(w2>>10)&7], dst_reg, get_ea_mode_str_32(g_cpu_ir), (w2>>4)&7);
+					break;
+
+				default:
+					sprintf(g_dasm_str, "fmove%s   FP%d, %s", float_data_format[(w2>>10)&7], dst_reg, get_ea_mode_str_32(g_cpu_ir));
+					break;
+			}
 			break;
 		}
 
 		case 0x4:	// ea to control
 		{
-			sprintf(g_dasm_str, "fmove.l   %s, %s", get_ea_mode_str_32(g_cpu_ir), spec_reg[(w2>>10)&7]);
+			sprintf(g_dasm_str, "fmovem.l   %s, ", get_ea_mode_str_32(g_cpu_ir));
+			if (w2 & 0x1000) strcat(g_dasm_str, "fpcr");
+			if (w2 & 0x0800) strcat(g_dasm_str, "/fpsr");
+			if (w2 & 0x0400) strcat(g_dasm_str, "/fpiar");
 			break;
 		}
 
 		case 0x5:	// control to ea
 		{
-			sprintf(g_dasm_str, "fmove.l   %s, %s", spec_reg[(w2>>10)&7], get_ea_mode_str_32(g_cpu_ir));
+			
+			strcpy(g_dasm_str, "fmovem.l   ");
+			if (w2 & 0x1000) strcat(g_dasm_str, "fpcr");
+			if (w2 & 0x0800) strcat(g_dasm_str, "/fpsr");
+			if (w2 & 0x0400) strcat(g_dasm_str, "/fpiar");
+			strcat(g_dasm_str, ", ");
+			strcat(g_dasm_str, get_ea_mode_str_32(g_cpu_ir));
 			break;
 		}
 

--- a/m68kdasm.c
+++ b/m68kdasm.c
@@ -1713,6 +1713,13 @@ static void d68040_fpu(void)
 	src = (w2 >> 10) & 0x7;
 	dst_reg = (w2 >> 7) & 0x7;
 
+	// special override for FMOVECR
+	if ((((w2 >> 13) & 0x7) == 2) && (((w2>>10)&0x7) == 7))
+	{
+		sprintf(g_dasm_str, "fmovecr   #$%0x, fp%d", (w2&0x7f), dst_reg);
+		return;
+	}
+
 	switch ((w2 >> 13) & 0x7)
 	{
 		case 0x0:

--- a/m68kdasm.c
+++ b/m68kdasm.c
@@ -1700,6 +1700,10 @@ static void d68040_fpu(void)
 	{
 		".l", ".s", ".x", ".p", ".w", ".d", ".b", ".?"
 	};
+	const char *spec_reg[8] =
+	{
+		"?", "FPIAR", "FPSR", "?", "FPCR", "?", "?", "?"
+	};
 
 	char mnemonic[40];
 	uint32 w2, src, dst_reg;
@@ -1786,21 +1790,88 @@ static void d68040_fpu(void)
 
 		case 0x3:
 		{
-			sprintf(g_dasm_str, "fmove /todo");
+			sprintf(g_dasm_str, "fmove   FP%d, %s", dst_reg, get_ea_mode_str_32(g_cpu_ir));
 			break;
 		}
 
-		case 0x4:
-		case 0x5:
+		case 0x4:	// ea to control
 		{
-			sprintf(g_dasm_str, "fmove /todo");
+			sprintf(g_dasm_str, "fmove.l   %s, %s", get_ea_mode_str_32(g_cpu_ir), spec_reg[(w2>>10)&7]);
 			break;
 		}
 
-		case 0x6:
-		case 0x7:
+		case 0x5:	// control to ea
 		{
-			sprintf(g_dasm_str, "fmovem /todo");
+			sprintf(g_dasm_str, "fmove.l   %s, %s", spec_reg[(w2>>10)&7], get_ea_mode_str_32(g_cpu_ir));
+			break;
+		}
+
+		case 0x6:	// memory to FPU, list
+		{
+			char temp[32];
+
+			if ((w2>>11) & 1)	// dynamic register list
+			{
+				sprintf(g_dasm_str, "fmovem.x   %s, D%d", get_ea_mode_str_32(g_cpu_ir), (w2>>4)&7);
+			}
+			else	// static register list
+			{
+				int i;
+
+				sprintf(g_dasm_str, "fmovem.x   %s, ", get_ea_mode_str_32(g_cpu_ir));
+
+				for (i = 0; i < 8; i++)
+				{
+					if (w2 & (1<<i))
+					{
+						if ((w2>>12) & 1)	// postincrement or control
+						{
+							sprintf(temp, "FP%d ", 7-i);
+						}
+						else			// predecrement
+						{
+							sprintf(temp, "FP%d ", i);
+						}
+						strcat(g_dasm_str, temp);
+					}
+				}
+			}
+			break;
+		}
+
+		case 0x7:	// FPU to memory, list
+		{
+			char temp[32];
+
+			if ((w2>>11) & 1)	// dynamic register list
+			{
+				sprintf(g_dasm_str, "fmovem.x   D%d, %s", (w2>>4)&7, get_ea_mode_str_32(g_cpu_ir));
+			}
+			else	// static register list
+			{
+				int i;
+
+				sprintf(g_dasm_str, "fmovem.x   ");
+
+				for (i = 0; i < 8; i++)
+				{
+					if (w2 & (1<<i))
+					{
+						if ((w2>>12) & 1)	// postincrement or control
+						{
+							sprintf(temp, "FP%d ", 7-i);
+						}
+						else			// predecrement
+						{
+							sprintf(temp, "FP%d ", i);
+						}
+						strcat(g_dasm_str, temp);
+					}
+				}
+
+				strcat(g_dasm_str, ", ");
+				strcat(g_dasm_str, get_ea_mode_str_32(g_cpu_ir));
+			}
 			break;
 		}
 

--- a/m68kfpu.c
+++ b/m68kfpu.c
@@ -322,6 +322,18 @@ static inline int TEST_CONDITION(int condition)
 		case 0x15:
 		case 0x05:		return (z || (n && !nan));			// Less Than or Equal
 
+		case 0x16:
+		case 0x06:		return !nan && !z;
+
+		case 0x17:
+		case 0x07:		return !nan;
+
+		case 0x18:
+		case 0x08:		return nan;
+
+		case 0x19:
+		case 0x09:		return nan || z;
+
 		case 0x1a:
 		case 0x0a:		return (nan || !(n || z));			// Not Less Than or Equal
 
@@ -1192,6 +1204,17 @@ static void fpgen_rm_reg(uint16 w2)
 			SET_CONDITION_CODES(REG_FP[dst]);
 			USE_CYCLES(3);
 			break;
+		}
+		case 0x1e:		// FGETEXP
+		{
+			floatx80 temp = source;
+			sint16 temp2;
+
+			temp2 = source.high;	// get the exponent
+			temp2 -= 0x3fff;	// take off the bias
+			REG_FP[dst] = double_to_fx80((double)temp2);
+			SET_CONDITION_CODES(REG_FP[dst]);
+			USE_CYCLES(6);
 		}
 		case 0x20:		// FDIV
 		{

--- a/m68kfpu.c
+++ b/m68kfpu.c
@@ -601,6 +601,21 @@ static void WRITE_EA_64(int ea, uint64 data)
 	}
 }
 
+static inline floatx80 load_extended_float80(uint32 ea)
+{
+	uint32 d1,d2;
+	uint16 d3;
+	floatx80 fp;
+
+	d3 = m68ki_read_16(ea);
+	d1 = m68ki_read_32(ea+4);
+	d2 = m68ki_read_32(ea+8);
+	fp.high = d3;
+	fp.low = ((uint64)d1<<32) | (d2 & 0xffffffff);
+
+	return fp;
+}
+
 static floatx80 READ_EA_FPE(int ea)
 {
 	floatx80 fpr;
@@ -611,34 +626,49 @@ static floatx80 READ_EA_FPE(int ea)
 	{
 		case 2:		// (An)
 		{
-			uint32 d1,d2;
-			uint16 d3;
 			uint32 ea = REG_A[reg];
-			d3 = m68ki_read_16(ea);
-			d1 = m68ki_read_32(ea+4);
-			d2 = m68ki_read_32(ea+8);
-			fpr.high = d3;
-			fpr.low = ((uint64)d1<<32) | (d2 & 0xffffffff);
+			fpr = load_extended_float80(ea);
 			break;
 		}
 
 		case 3:		// (An)+
 		{
-			uint32 d1,d2;
-			uint16 d3;
 			uint32 ea = REG_A[reg];
 			REG_A[reg] += 12;
-			d3 = m68ki_read_16(ea);
-			d1 = m68ki_read_32(ea+4);
-			d2 = m68ki_read_32(ea+8);
-			fpr.high = d3;
-			fpr.low = ((uint64)d1<<32) | (d2 & 0xffffffff);
+			fpr = load_extended_float80(ea);
 			break;
 		}
-		default:	fatalerror("M68kFPU: READ_EA_FPE: unhandled mode %d, reg %d, at %08X\n", mode, reg, REG_PC);
+
+		case 7:	// extended modes
+		{
+			switch (reg)
+			{
+				case 3:	// (d16,PC,Dx.w)
+					{
+						uint32 ea = EA_PCIX_32();
+						fpr = load_extended_float80(ea);
+					}
+					break;
+
+				default:
+					fatalerror("M68kFPU: READ_EA_FPE0: unhandled mode %d, reg %d, at %08X\n", mode, reg, REG_PC);
+					break;
+			}
+		}
+		break;
+
+		default:	fatalerror("M68kFPU: READ_EA_FPE1: unhandled mode %d, reg %d, at %08X\n", mode, reg, REG_PC); break;
 	}
 
 	return fpr;
+}
+
+static inline void store_extended_float80(uint32 ea, floatx80 fpr)
+{
+	m68ki_write_16(ea+0, fpr.high);
+	m68ki_write_16(ea+2, 0);
+	m68ki_write_32(ea+4, (fpr.low>>32)&0xffffffff);
+	m68ki_write_32(ea+8, fpr.low&0xffffffff);
 }
 
 static void WRITE_EA_FPE(int ea, floatx80 fpr)
@@ -652,10 +682,7 @@ static void WRITE_EA_FPE(int ea, floatx80 fpr)
 		{
 			uint32 ea;
 			ea = REG_A[reg];
-			m68ki_write_16(ea+0, fpr.high);
-			m68ki_write_16(ea+2, 0);
-			m68ki_write_32(ea+4, (fpr.low>>32)&0xffffffff);
-			m68ki_write_32(ea+8, fpr.low&0xffffffff);
+			store_extended_float80(ea, fpr);
 			break;
 		}
 
@@ -663,10 +690,7 @@ static void WRITE_EA_FPE(int ea, floatx80 fpr)
 		{
 			uint32 ea;
 			ea = REG_A[reg];
-			m68ki_write_16(ea+0, fpr.high);
-			m68ki_write_16(ea+2, 0);
-			m68ki_write_32(ea+4, (fpr.low>>32)&0xffffffff);
-			m68ki_write_32(ea+8, fpr.low&0xffffffff);
+			store_extended_float80(ea, fpr);
 			REG_A[reg] += 12;
 			break;
 		}
@@ -676,10 +700,7 @@ static void WRITE_EA_FPE(int ea, floatx80 fpr)
 			uint32 ea;
 			REG_A[reg] -= 12;
 			ea = REG_A[reg];
-			m68ki_write_16(ea+0, fpr.high);
-			m68ki_write_16(ea+2, 0);
-			m68ki_write_32(ea+4, (fpr.low>>32)&0xffffffff);
-			m68ki_write_32(ea+8, fpr.low&0xffffffff);
+			store_extended_float80(ea, fpr);
 			break;
 		}
 
@@ -687,7 +708,6 @@ static void WRITE_EA_FPE(int ea, floatx80 fpr)
 		{
 			switch (reg)
 			{
-				case 3:	// (d8,PC,Xn)
 				default:	fatalerror("M68kFPU: WRITE_EA_FPE: unhandled mode %d, reg %d, at %08X\n", mode, reg, REG_PC);
 			}
 		}
@@ -705,6 +725,8 @@ static void fpgen_rm_reg(uint16 w2)
 	int dst = (w2 >>  7) & 0x7;
 	int opmode = w2 & 0x7f;
 	floatx80 source;
+
+	// fmovecr #$f, fp0	f200 5c0f
 
 	if (rm)
 	{
@@ -751,7 +773,72 @@ static void fpgen_rm_reg(uint16 w2)
 				source = int32_to_floatx80((sint32)d);
 				break;
 			}
-			default:	fatalerror("fmove_rm_reg: invalid source specifier at %08X\n", REG_PC-4);
+			case 7:		// FMOVECR load from constant ROM
+			{
+				switch (w2 & 0x7f)
+				{
+					case 0x0:	// Pi
+						source.high = 0x4000;
+						source.low = U64(0xc90fdaa22168c235);
+						break;
+
+					case 0xb:	// log10(2)
+						source.high = 0x3ffd;
+						source.low = U64(0x9a209a84fbcff798);
+						break;
+
+					case 0xc:	// e
+						source.high = 0x4000;
+						source.low = U64(0xadf85458a2bb4a9b);
+						break;
+
+					case 0xd:	// log2(e)
+						source.high = 0x3fff;
+						source.low = U64(0xb8aa3b295c17f0bc);
+						break;
+
+					case 0xe:	// log10(e)
+						source.high = 0x3ffd;
+						source.low = U64(0xde5bd8a937287195);
+						break;
+
+					case 0xf:	// 0.0
+						source = int32_to_floatx80((sint32)0);
+						break;
+
+					case 0x30:	// ln(2)
+						source.high = 0x3ffe;
+						source.low = U64(0xb17217f7d1cf79ac);
+						break;
+
+					case 0x31:	// ln(10)
+						source.high = 0x4000;
+						source.low = U64(0x935d8dddaaa8ac17);
+						break;
+
+					case 0x32:	// 1 (or 100?  manuals are unclear, but 1 would make more sense)
+						source = int32_to_floatx80((sint32)1);
+						break;
+
+					case 0x33:	// 10^1
+						source = int32_to_floatx80((sint32)10);
+						break;
+
+					case 0x34:	// 10^2
+						source = int32_to_floatx80((sint32)10*10);
+						break;
+
+					default:
+						fatalerror("fmove_rm_reg: unknown constant ROM offset %x at %08x\n", w2&0x7f, REG_PC-4);
+						break;
+				}
+
+				// handle it right here, the usual opmode bits aren't valid in the FMOVECR case
+				REG_FP[dst] = source;
+				USE_CYCLES(4);
+				return;
+			}
+			default:	fatalerror("fmove_rm_reg: invalid source specifier %x at %08X\n", src, REG_PC-4);
 		}
 	}
 	else

--- a/m68kmake.c
+++ b/m68kmake.c
@@ -3,10 +3,11 @@
 /* ======================================================================== */
 /*
  *                                  MUSASHI
- *                                Version 4.55
+ *                                Version 4.60
  *
  * A portable Motorola M680x0 processor emulation engine.
  * Copyright Karl Stenerud.  All rights reserved.
+ * FPU and MMU by R. Belmont.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -56,7 +57,7 @@
  */
 
 
-static const char g_version[] = "4.55";
+static const char g_version[] = "4.60";
 
 /* ======================================================================== */
 /* =============================== INCLUDES =============================== */

--- a/softfloat/README.txt
+++ b/softfloat/README.txt
@@ -1,0 +1,78 @@
+MAME note: this package is derived from the following original SoftFloat 
+package and has been "re-packaged" to work with MAME's conventions and
+build system.  The source files come from bits64/ and bits64/templates
+in the original distribution as MAME requires a compiler with a 64-bit
+integer type.
+
+
+Package Overview for SoftFloat Release 2b
+
+John R. Hauser
+2002 May 27
+
+
+----------------------------------------------------------------------------
+Overview
+
+SoftFloat is a software implementation of floating-point that conforms to
+the IEC/IEEE Standard for Binary Floating-Point Arithmetic.  SoftFloat is
+distributed in the form of C source code.  Compiling the SoftFloat sources
+generates two things:
+
+-- A SoftFloat object file (typically `softfloat.o') containing the complete
+   set of IEC/IEEE floating-point routines.
+
+-- A `timesoftfloat' program for evaluating the speed of the SoftFloat
+   routines.  (The SoftFloat module is linked into this program.)
+
+The SoftFloat package is documented in four text files:
+
+   SoftFloat.txt          Documentation for using the SoftFloat functions.
+   SoftFloat-source.txt   Documentation for compiling SoftFloat.
+   SoftFloat-history.txt  History of major changes to SoftFloat.
+   timesoftfloat.txt      Documentation for using `timesoftfloat'.
+
+Other files in the package comprise the source code for SoftFloat.
+
+Please be aware that some work is involved in porting this software to other
+targets.  It is not just a matter of getting `make' to complete without
+error messages.  I would have written the code that way if I could, but
+there are fundamental differences between systems that can't be hidden.
+You should not attempt to compile SoftFloat without first reading both
+`SoftFloat.txt' and `SoftFloat-source.txt'.
+
+
+----------------------------------------------------------------------------
+Legal Notice
+
+SoftFloat was written by me, John R. Hauser.  This work was made possible in
+part by the International Computer Science Institute, located at Suite 600,
+1947 Center Street, Berkeley, California 94704.  Funding was partially
+provided by the National Science Foundation under grant MIP-9311980.  The
+original version of this code was written as part of a project to build
+a fixed-point vector processor in collaboration with the University of
+California at Berkeley, overseen by Profs. Nelson Morgan and John Wawrzynek.
+
+THIS SOFTWARE IS DISTRIBUTED AS IS, FOR FREE.  Although reasonable effort
+has been made to avoid it, THIS SOFTWARE MAY CONTAIN FAULTS THAT WILL AT
+TIMES RESULT IN INCORRECT BEHAVIOR.  USE OF THIS SOFTWARE IS RESTRICTED TO
+PERSONS AND ORGANIZATIONS WHO CAN AND WILL TAKE FULL RESPONSIBILITY FOR ALL
+LOSSES, COSTS, OR OTHER PROBLEMS THEY INCUR DUE TO THE SOFTWARE, AND WHO
+FURTHERMORE EFFECTIVELY INDEMNIFY JOHN HAUSER AND THE INTERNATIONAL COMPUTER
+SCIENCE INSTITUTE (possibly via similar legal warning) AGAINST ALL LOSSES,
+COSTS, OR OTHER PROBLEMS INCURRED BY THEIR CUSTOMERS AND CLIENTS DUE TO THE
+SOFTWARE.
+
+Derivative works are acceptable, even for commercial purposes, provided
+that the minimal documentation requirements stated in the source code are
+satisfied.
+
+
+----------------------------------------------------------------------------
+Contact Information
+
+At the time of this writing, the most up-to-date information about
+SoftFloat and the latest release can be found at the Web page `http://
+www.cs.berkeley.edu/~jhauser/arithmetic/SoftFloat.html'.
+
+

--- a/softfloat/mamesf.h
+++ b/softfloat/mamesf.h
@@ -1,0 +1,61 @@
+/*----------------------------------------------------------------------------
+| One of the macros `BIGENDIAN' or `LITTLEENDIAN' must be defined.
+*----------------------------------------------------------------------------*/
+#ifdef LSB_FIRST
+#define LITTLEENDIAN
+#else
+#define BIGENDIAN
+#endif
+
+/*----------------------------------------------------------------------------
+| The macro `BITS64' can be defined to indicate that 64-bit integer types are
+| supported by the compiler.
+*----------------------------------------------------------------------------*/
+#define BITS64
+
+/*----------------------------------------------------------------------------
+| Each of the following `typedef's defines the most convenient type that holds
+| integers of at least as many bits as specified.  For example, `uint8' should
+| be the most convenient type that can hold unsigned integers of as many as
+| 8 bits.  The `flag' type must be able to hold either a 0 or 1.  For most
+| implementations of C, `flag', `uint8', and `int8' should all be `typedef'ed
+| to the same as `int'.
+*----------------------------------------------------------------------------*/
+
+typedef sint8 flag;
+typedef sint8 int8;
+typedef sint16 int16;
+typedef sint32 int32;
+typedef sint64 int64;
+
+/*----------------------------------------------------------------------------
+| Each of the following `typedef's defines a type that holds integers
+| of _exactly_ the number of bits specified.  For instance, for most
+| implementation of C, `bits16' and `sbits16' should be `typedef'ed to
+| `unsigned short int' and `signed short int' (or `short int'), respectively.
+*----------------------------------------------------------------------------*/
+typedef uint8 bits8;
+typedef sint8 sbits8;
+typedef uint16 bits16;
+typedef sint16 sbits16;
+typedef uint32 bits32;
+typedef sint32 sbits32;
+typedef uint64 bits64;
+typedef sint64 sbits64;
+
+/*----------------------------------------------------------------------------
+| The `LIT64' macro takes as its argument a textual integer literal and
+| if necessary ``marks'' the literal as having a 64-bit integer type.
+| For example, the GNU C Compiler (`gcc') requires that 64-bit literals be
+| appended with the letters `LL' standing for `long long', which is `gcc's
+| name for the 64-bit integer type.  Some compilers may allow `LIT64' to be
+| defined as the identity macro:  `#define LIT64( a ) a'.
+*----------------------------------------------------------------------------*/
+#define LIT64( a ) a##ULL
+
+/*----------------------------------------------------------------------------
+| The macro `INLINE' can be used before functions that should be inlined.  If
+| a compiler does not support explicit inlining, this macro should be defined
+| to be `static'.
+*----------------------------------------------------------------------------*/
+// MAME defines INLINE

--- a/softfloat/milieu.h
+++ b/softfloat/milieu.h
@@ -1,0 +1,42 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEC/IEEE Floating-point Arithmetic
+Package, Release 2b.
+
+Written by John R. Hauser.  This work was made possible in part by the
+International Computer Science Institute, located at Suite 600, 1947 Center
+Street, Berkeley, California 94704.  Funding was partially provided by the
+National Science Foundation under grant MIP-9311980.  The original version
+of this code was written as part of a project to build a fixed-point vector
+processor in collaboration with the University of California at Berkeley,
+overseen by Profs. Nelson Morgan and John Wawrzynek.  More information
+is available through the Web page `http://www.cs.berkeley.edu/~jhauser/
+arithmetic/SoftFloat.html'.
+
+THIS SOFTWARE IS DISTRIBUTED AS IS, FOR FREE.  Although reasonable effort has
+been made to avoid it, THIS SOFTWARE MAY CONTAIN FAULTS THAT WILL AT TIMES
+RESULT IN INCORRECT BEHAVIOR.  USE OF THIS SOFTWARE IS RESTRICTED TO PERSONS
+AND ORGANIZATIONS WHO CAN AND WILL TAKE FULL RESPONSIBILITY FOR ALL LOSSES,
+COSTS, OR OTHER PROBLEMS THEY INCUR DUE TO THE SOFTWARE, AND WHO FURTHERMORE
+EFFECTIVELY INDEMNIFY JOHN HAUSER AND THE INTERNATIONAL COMPUTER SCIENCE
+INSTITUTE (possibly via similar legal warning) AGAINST ALL LOSSES, COSTS, OR
+OTHER PROBLEMS INCURRED BY THEIR CUSTOMERS AND CLIENTS DUE TO THE SOFTWARE.
+
+Derivative works are acceptable, even for commercial purposes, so long as
+(1) the source code for the derivative work includes prominent notice that
+the work is derivative, and (2) the source code includes prominent notice with
+these four paragraphs for those parts of this code that are retained.
+
+=============================================================================*/
+
+/*----------------------------------------------------------------------------
+| Include common integer types and flags.
+*----------------------------------------------------------------------------*/
+#include "mamesf.h"
+
+/*----------------------------------------------------------------------------
+| Symbolic Boolean literals.
+*----------------------------------------------------------------------------*/
+#define FALSE 0
+#define TRUE 1

--- a/softfloat/softfloat-macros
+++ b/softfloat/softfloat-macros
@@ -1,0 +1,732 @@
+
+/*============================================================================
+
+This C source fragment is part of the SoftFloat IEC/IEEE Floating-point
+Arithmetic Package, Release 2b.
+
+Written by John R. Hauser.  This work was made possible in part by the
+International Computer Science Institute, located at Suite 600, 1947 Center
+Street, Berkeley, California 94704.  Funding was partially provided by the
+National Science Foundation under grant MIP-9311980.  The original version
+of this code was written as part of a project to build a fixed-point vector
+processor in collaboration with the University of California at Berkeley,
+overseen by Profs. Nelson Morgan and John Wawrzynek.  More information
+is available through the Web page `http://www.cs.berkeley.edu/~jhauser/
+arithmetic/SoftFloat.html'.
+
+THIS SOFTWARE IS DISTRIBUTED AS IS, FOR FREE.  Although reasonable effort has
+been made to avoid it, THIS SOFTWARE MAY CONTAIN FAULTS THAT WILL AT TIMES
+RESULT IN INCORRECT BEHAVIOR.  USE OF THIS SOFTWARE IS RESTRICTED TO PERSONS
+AND ORGANIZATIONS WHO CAN AND WILL TAKE FULL RESPONSIBILITY FOR ALL LOSSES,
+COSTS, OR OTHER PROBLEMS THEY INCUR DUE TO THE SOFTWARE, AND WHO FURTHERMORE
+EFFECTIVELY INDEMNIFY JOHN HAUSER AND THE INTERNATIONAL COMPUTER SCIENCE
+INSTITUTE (possibly via similar legal notice) AGAINST ALL LOSSES, COSTS, OR
+OTHER PROBLEMS INCURRED BY THEIR CUSTOMERS AND CLIENTS DUE TO THE SOFTWARE.
+
+Derivative works are acceptable, even for commercial purposes, so long as
+(1) the source code for the derivative work includes prominent notice that
+the work is derivative, and (2) the source code includes prominent notice with
+these four paragraphs for those parts of this code that are retained.
+
+=============================================================================*/
+
+/*----------------------------------------------------------------------------
+| Shifts `a' right by the number of bits given in `count'.  If any nonzero
+| bits are shifted off, they are ``jammed'' into the least significant bit of
+| the result by setting the least significant bit to 1.  The value of `count'
+| can be arbitrarily large; in particular, if `count' is greater than 32, the
+| result will be either 0 or 1, depending on whether `a' is zero or nonzero.
+| The result is stored in the location pointed to by `zPtr'.
+*----------------------------------------------------------------------------*/
+
+static inline void shift32RightJamming( bits32 a, int16 count, bits32 *zPtr )
+{
+    bits32 z;
+
+    if ( count == 0 ) {
+        z = a;
+    }
+    else if ( count < 32 ) {
+        z = ( a>>count ) | ( ( a<<( ( - count ) & 31 ) ) != 0 );
+    }
+    else {
+        z = ( a != 0 );
+    }
+    *zPtr = z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Shifts `a' right by the number of bits given in `count'.  If any nonzero
+| bits are shifted off, they are ``jammed'' into the least significant bit of
+| the result by setting the least significant bit to 1.  The value of `count'
+| can be arbitrarily large; in particular, if `count' is greater than 64, the
+| result will be either 0 or 1, depending on whether `a' is zero or nonzero.
+| The result is stored in the location pointed to by `zPtr'.
+*----------------------------------------------------------------------------*/
+
+static inline void shift64RightJamming( bits64 a, int16 count, bits64 *zPtr )
+{
+    bits64 z;
+
+    if ( count == 0 ) {
+        z = a;
+    }
+    else if ( count < 64 ) {
+        z = ( a>>count ) | ( ( a<<( ( - count ) & 63 ) ) != 0 );
+    }
+    else {
+        z = ( a != 0 );
+    }
+    *zPtr = z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Shifts the 128-bit value formed by concatenating `a0' and `a1' right by 64
+| _plus_ the number of bits given in `count'.  The shifted result is at most
+| 64 nonzero bits; this is stored at the location pointed to by `z0Ptr'.  The
+| bits shifted off form a second 64-bit result as follows:  The _last_ bit
+| shifted off is the most-significant bit of the extra result, and the other
+| 63 bits of the extra result are all zero if and only if _all_but_the_last_
+| bits shifted off were all zero.  This extra result is stored in the location
+| pointed to by `z1Ptr'.  The value of `count' can be arbitrarily large.
+|     (This routine makes more sense if `a0' and `a1' are considered to form
+| a fixed-point value with binary point between `a0' and `a1'.  This fixed-
+| point value is shifted right by the number of bits given in `count', and
+| the integer part of the result is returned at the location pointed to by
+| `z0Ptr'.  The fractional part of the result may be slightly corrupted as
+| described above, and is returned at the location pointed to by `z1Ptr'.)
+*----------------------------------------------------------------------------*/
+
+static inline void
+ shift64ExtraRightJamming(
+     bits64 a0, bits64 a1, int16 count, bits64 *z0Ptr, bits64 *z1Ptr )
+{
+    bits64 z0, z1;
+    int8 negCount = ( - count ) & 63;
+
+    if ( count == 0 ) {
+        z1 = a1;
+        z0 = a0;
+    }
+    else if ( count < 64 ) {
+        z1 = ( a0<<negCount ) | ( a1 != 0 );
+        z0 = a0>>count;
+    }
+    else {
+        if ( count == 64 ) {
+            z1 = a0 | ( a1 != 0 );
+        }
+        else {
+            z1 = ( ( a0 | a1 ) != 0 );
+        }
+        z0 = 0;
+    }
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Shifts the 128-bit value formed by concatenating `a0' and `a1' right by the
+| number of bits given in `count'.  Any bits shifted off are lost.  The value
+| of `count' can be arbitrarily large; in particular, if `count' is greater
+| than 128, the result will be 0.  The result is broken into two 64-bit pieces
+| which are stored at the locations pointed to by `z0Ptr' and `z1Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ shift128Right(
+     bits64 a0, bits64 a1, int16 count, bits64 *z0Ptr, bits64 *z1Ptr )
+{
+    bits64 z0, z1;
+    int8 negCount = ( - count ) & 63;
+
+    if ( count == 0 ) {
+        z1 = a1;
+        z0 = a0;
+    }
+    else if ( count < 64 ) {
+        z1 = ( a0<<negCount ) | ( a1>>count );
+        z0 = a0>>count;
+    }
+    else {
+        z1 = ( count < 64 ) ? ( a0>>( count & 63 ) ) : 0;
+        z0 = 0;
+    }
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Shifts the 128-bit value formed by concatenating `a0' and `a1' right by the
+| number of bits given in `count'.  If any nonzero bits are shifted off, they
+| are ``jammed'' into the least significant bit of the result by setting the
+| least significant bit to 1.  The value of `count' can be arbitrarily large;
+| in particular, if `count' is greater than 128, the result will be either
+| 0 or 1, depending on whether the concatenation of `a0' and `a1' is zero or
+| nonzero.  The result is broken into two 64-bit pieces which are stored at
+| the locations pointed to by `z0Ptr' and `z1Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ shift128RightJamming(
+     bits64 a0, bits64 a1, int16 count, bits64 *z0Ptr, bits64 *z1Ptr )
+{
+    bits64 z0, z1;
+    int8 negCount = ( - count ) & 63;
+
+    if ( count == 0 ) {
+        z1 = a1;
+        z0 = a0;
+    }
+    else if ( count < 64 ) {
+        z1 = ( a0<<negCount ) | ( a1>>count ) | ( ( a1<<negCount ) != 0 );
+        z0 = a0>>count;
+    }
+    else {
+        if ( count == 64 ) {
+            z1 = a0 | ( a1 != 0 );
+        }
+        else if ( count < 128 ) {
+            z1 = ( a0>>( count & 63 ) ) | ( ( ( a0<<negCount ) | a1 ) != 0 );
+        }
+        else {
+            z1 = ( ( a0 | a1 ) != 0 );
+        }
+        z0 = 0;
+    }
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Shifts the 192-bit value formed by concatenating `a0', `a1', and `a2' right
+| by 64 _plus_ the number of bits given in `count'.  The shifted result is
+| at most 128 nonzero bits; these are broken into two 64-bit pieces which are
+| stored at the locations pointed to by `z0Ptr' and `z1Ptr'.  The bits shifted
+| off form a third 64-bit result as follows:  The _last_ bit shifted off is
+| the most-significant bit of the extra result, and the other 63 bits of the
+| extra result are all zero if and only if _all_but_the_last_ bits shifted off
+| were all zero.  This extra result is stored in the location pointed to by
+| `z2Ptr'.  The value of `count' can be arbitrarily large.
+|     (This routine makes more sense if `a0', `a1', and `a2' are considered
+| to form a fixed-point value with binary point between `a1' and `a2'.  This
+| fixed-point value is shifted right by the number of bits given in `count',
+| and the integer part of the result is returned at the locations pointed to
+| by `z0Ptr' and `z1Ptr'.  The fractional part of the result may be slightly
+| corrupted as described above, and is returned at the location pointed to by
+| `z2Ptr'.)
+*----------------------------------------------------------------------------*/
+
+static inline void
+ shift128ExtraRightJamming(
+     bits64 a0,
+     bits64 a1,
+     bits64 a2,
+     int16 count,
+     bits64 *z0Ptr,
+     bits64 *z1Ptr,
+     bits64 *z2Ptr
+ )
+{
+    bits64 z0, z1, z2;
+    int8 negCount = ( - count ) & 63;
+
+    if ( count == 0 ) {
+        z2 = a2;
+        z1 = a1;
+        z0 = a0;
+    }
+    else {
+        if ( count < 64 ) {
+            z2 = a1<<negCount;
+            z1 = ( a0<<negCount ) | ( a1>>count );
+            z0 = a0>>count;
+        }
+        else {
+            if ( count == 64 ) {
+                z2 = a1;
+                z1 = a0;
+            }
+            else {
+                a2 |= a1;
+                if ( count < 128 ) {
+                    z2 = a0<<negCount;
+                    z1 = a0>>( count & 63 );
+                }
+                else {
+                    z2 = ( count == 128 ) ? a0 : ( a0 != 0 );
+                    z1 = 0;
+                }
+            }
+            z0 = 0;
+        }
+        z2 |= ( a2 != 0 );
+    }
+    *z2Ptr = z2;
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Shifts the 128-bit value formed by concatenating `a0' and `a1' left by the
+| number of bits given in `count'.  Any bits shifted off are lost.  The value
+| of `count' must be less than 64.  The result is broken into two 64-bit
+| pieces which are stored at the locations pointed to by `z0Ptr' and `z1Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ shortShift128Left(
+     bits64 a0, bits64 a1, int16 count, bits64 *z0Ptr, bits64 *z1Ptr )
+{
+
+    *z1Ptr = a1<<count;
+    *z0Ptr =
+        ( count == 0 ) ? a0 : ( a0<<count ) | ( a1>>( ( - count ) & 63 ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Shifts the 192-bit value formed by concatenating `a0', `a1', and `a2' left
+| by the number of bits given in `count'.  Any bits shifted off are lost.
+| The value of `count' must be less than 64.  The result is broken into three
+| 64-bit pieces which are stored at the locations pointed to by `z0Ptr',
+| `z1Ptr', and `z2Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ shortShift192Left(
+     bits64 a0,
+     bits64 a1,
+     bits64 a2,
+     int16 count,
+     bits64 *z0Ptr,
+     bits64 *z1Ptr,
+     bits64 *z2Ptr
+ )
+{
+    bits64 z0, z1, z2;
+    int8 negCount;
+
+    z2 = a2<<count;
+    z1 = a1<<count;
+    z0 = a0<<count;
+    if ( 0 < count ) {
+        negCount = ( ( - count ) & 63 );
+        z1 |= a2>>negCount;
+        z0 |= a1>>negCount;
+    }
+    *z2Ptr = z2;
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Adds the 128-bit value formed by concatenating `a0' and `a1' to the 128-bit
+| value formed by concatenating `b0' and `b1'.  Addition is modulo 2^128, so
+| any carry out is lost.  The result is broken into two 64-bit pieces which
+| are stored at the locations pointed to by `z0Ptr' and `z1Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ add128(
+     bits64 a0, bits64 a1, bits64 b0, bits64 b1, bits64 *z0Ptr, bits64 *z1Ptr )
+{
+    bits64 z1;
+
+    z1 = a1 + b1;
+    *z1Ptr = z1;
+    *z0Ptr = a0 + b0 + ( z1 < a1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Adds the 192-bit value formed by concatenating `a0', `a1', and `a2' to the
+| 192-bit value formed by concatenating `b0', `b1', and `b2'.  Addition is
+| modulo 2^192, so any carry out is lost.  The result is broken into three
+| 64-bit pieces which are stored at the locations pointed to by `z0Ptr',
+| `z1Ptr', and `z2Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ add192(
+     bits64 a0,
+     bits64 a1,
+     bits64 a2,
+     bits64 b0,
+     bits64 b1,
+     bits64 b2,
+     bits64 *z0Ptr,
+     bits64 *z1Ptr,
+     bits64 *z2Ptr
+ )
+{
+    bits64 z0, z1, z2;
+    uint8 carry0, carry1;
+
+    z2 = a2 + b2;
+    carry1 = ( z2 < a2 );
+    z1 = a1 + b1;
+    carry0 = ( z1 < a1 );
+    z0 = a0 + b0;
+    z1 += carry1;
+    z0 += ( z1 < carry1 );
+    z0 += carry0;
+    *z2Ptr = z2;
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Subtracts the 128-bit value formed by concatenating `b0' and `b1' from the
+| 128-bit value formed by concatenating `a0' and `a1'.  Subtraction is modulo
+| 2^128, so any borrow out (carry out) is lost.  The result is broken into two
+| 64-bit pieces which are stored at the locations pointed to by `z0Ptr' and
+| `z1Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ sub128(
+     bits64 a0, bits64 a1, bits64 b0, bits64 b1, bits64 *z0Ptr, bits64 *z1Ptr )
+{
+
+    *z1Ptr = a1 - b1;
+    *z0Ptr = a0 - b0 - ( a1 < b1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Subtracts the 192-bit value formed by concatenating `b0', `b1', and `b2'
+| from the 192-bit value formed by concatenating `a0', `a1', and `a2'.
+| Subtraction is modulo 2^192, so any borrow out (carry out) is lost.  The
+| result is broken into three 64-bit pieces which are stored at the locations
+| pointed to by `z0Ptr', `z1Ptr', and `z2Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ sub192(
+     bits64 a0,
+     bits64 a1,
+     bits64 a2,
+     bits64 b0,
+     bits64 b1,
+     bits64 b2,
+     bits64 *z0Ptr,
+     bits64 *z1Ptr,
+     bits64 *z2Ptr
+ )
+{
+    bits64 z0, z1, z2;
+    uint8 borrow0, borrow1;
+
+    z2 = a2 - b2;
+    borrow1 = ( a2 < b2 );
+    z1 = a1 - b1;
+    borrow0 = ( a1 < b1 );
+    z0 = a0 - b0;
+    z0 -= ( z1 < borrow1 );
+    z1 -= borrow1;
+    z0 -= borrow0;
+    *z2Ptr = z2;
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Multiplies `a' by `b' to obtain a 128-bit product.  The product is broken
+| into two 64-bit pieces which are stored at the locations pointed to by
+| `z0Ptr' and `z1Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void mul64To128( bits64 a, bits64 b, bits64 *z0Ptr, bits64 *z1Ptr )
+{
+    bits32 aHigh, aLow, bHigh, bLow;
+    bits64 z0, zMiddleA, zMiddleB, z1;
+
+    aLow = a;
+    aHigh = a>>32;
+    bLow = b;
+    bHigh = b>>32;
+    z1 = ( (bits64) aLow ) * bLow;
+    zMiddleA = ( (bits64) aLow ) * bHigh;
+    zMiddleB = ( (bits64) aHigh ) * bLow;
+    z0 = ( (bits64) aHigh ) * bHigh;
+    zMiddleA += zMiddleB;
+    z0 += ( ( (bits64) ( zMiddleA < zMiddleB ) )<<32 ) + ( zMiddleA>>32 );
+    zMiddleA <<= 32;
+    z1 += zMiddleA;
+    z0 += ( z1 < zMiddleA );
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Multiplies the 128-bit value formed by concatenating `a0' and `a1' by
+| `b' to obtain a 192-bit product.  The product is broken into three 64-bit
+| pieces which are stored at the locations pointed to by `z0Ptr', `z1Ptr', and
+| `z2Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ mul128By64To192(
+     bits64 a0,
+     bits64 a1,
+     bits64 b,
+     bits64 *z0Ptr,
+     bits64 *z1Ptr,
+     bits64 *z2Ptr
+ )
+{
+    bits64 z0, z1, z2, more1;
+
+    mul64To128( a1, b, &z1, &z2 );
+    mul64To128( a0, b, &z0, &more1 );
+    add128( z0, more1, 0, z1, &z0, &z1 );
+    *z2Ptr = z2;
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Multiplies the 128-bit value formed by concatenating `a0' and `a1' to the
+| 128-bit value formed by concatenating `b0' and `b1' to obtain a 256-bit
+| product.  The product is broken into four 64-bit pieces which are stored at
+| the locations pointed to by `z0Ptr', `z1Ptr', `z2Ptr', and `z3Ptr'.
+*----------------------------------------------------------------------------*/
+
+static inline void
+ mul128To256(
+     bits64 a0,
+     bits64 a1,
+     bits64 b0,
+     bits64 b1,
+     bits64 *z0Ptr,
+     bits64 *z1Ptr,
+     bits64 *z2Ptr,
+     bits64 *z3Ptr
+ )
+{
+    bits64 z0, z1, z2, z3;
+    bits64 more1, more2;
+
+    mul64To128( a1, b1, &z2, &z3 );
+    mul64To128( a1, b0, &z1, &more2 );
+    add128( z1, more2, 0, z2, &z1, &z2 );
+    mul64To128( a0, b0, &z0, &more1 );
+    add128( z0, more1, 0, z1, &z0, &z1 );
+    mul64To128( a0, b1, &more1, &more2 );
+    add128( more1, more2, 0, z2, &more1, &z2 );
+    add128( z0, z1, 0, more1, &z0, &z1 );
+    *z3Ptr = z3;
+    *z2Ptr = z2;
+    *z1Ptr = z1;
+    *z0Ptr = z0;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns an approximation to the 64-bit integer quotient obtained by dividing
+| `b' into the 128-bit value formed by concatenating `a0' and `a1'.  The
+| divisor `b' must be at least 2^63.  If q is the exact quotient truncated
+| toward zero, the approximation returned lies between q and q + 2 inclusive.
+| If the exact quotient q is larger than 64 bits, the maximum positive 64-bit
+| unsigned integer is returned.
+*----------------------------------------------------------------------------*/
+
+static inline bits64 estimateDiv128To64( bits64 a0, bits64 a1, bits64 b )
+{
+    bits64 b0, b1;
+    bits64 rem0, rem1, term0, term1;
+    bits64 z;
+
+    if ( b <= a0 ) return LIT64( 0xFFFFFFFFFFFFFFFF );
+    b0 = b>>32;
+    z = ( b0<<32 <= a0 ) ? LIT64( 0xFFFFFFFF00000000 ) : ( a0 / b0 )<<32;
+    mul64To128( b, z, &term0, &term1 );
+    sub128( a0, a1, term0, term1, &rem0, &rem1 );
+    while ( ( (sbits64) rem0 ) < 0 ) {
+        z -= LIT64( 0x100000000 );
+        b1 = b<<32;
+        add128( rem0, rem1, b0, b1, &rem0, &rem1 );
+    }
+    rem0 = ( rem0<<32 ) | ( rem1>>32 );
+    z |= ( b0<<32 <= rem0 ) ? 0xFFFFFFFF : rem0 / b0;
+    return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns an approximation to the square root of the 32-bit significand given
+| by `a'.  Considered as an integer, `a' must be at least 2^31.  If bit 0 of
+| `aExp' (the least significant bit) is 1, the integer returned approximates
+| 2^31*sqrt(`a'/2^31), where `a' is considered an integer.  If bit 0 of `aExp'
+| is 0, the integer returned approximates 2^31*sqrt(`a'/2^30).  In either
+| case, the approximation returned lies strictly within +/-2 of the exact
+| value.
+*----------------------------------------------------------------------------*/
+
+static inline bits32 estimateSqrt32( int16 aExp, bits32 a )
+{
+    static const bits16 sqrtOddAdjustments[] = {
+        0x0004, 0x0022, 0x005D, 0x00B1, 0x011D, 0x019F, 0x0236, 0x02E0,
+        0x039C, 0x0468, 0x0545, 0x0631, 0x072B, 0x0832, 0x0946, 0x0A67
+    };
+    static const bits16 sqrtEvenAdjustments[] = {
+        0x0A2D, 0x08AF, 0x075A, 0x0629, 0x051A, 0x0429, 0x0356, 0x029E,
+        0x0200, 0x0179, 0x0109, 0x00AF, 0x0068, 0x0034, 0x0012, 0x0002
+    };
+    int8 index;
+    bits32 z;
+
+    index = ( a>>27 ) & 15;
+    if ( aExp & 1 ) {
+        z = 0x4000 + ( a>>17 ) - sqrtOddAdjustments[ index ];
+        z = ( ( a / z )<<14 ) + ( z<<15 );
+        a >>= 1;
+    }
+    else {
+        z = 0x8000 + ( a>>17 ) - sqrtEvenAdjustments[ index ];
+        z = a / z + z;
+        z = ( 0x20000 <= z ) ? 0xFFFF8000 : ( z<<15 );
+        if ( z <= a ) return (bits32) ( ( (sbits32) a )>>1 );
+    }
+    return ( (bits32) ( ( ( (bits64) a )<<31 ) / z ) ) + ( z>>1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the number of leading 0 bits before the most-significant 1 bit of
+| `a'.  If `a' is zero, 32 is returned.
+*----------------------------------------------------------------------------*/
+
+static int8 countLeadingZeros32( bits32 a )
+{
+    static const int8 countLeadingZerosHigh[] = {
+        8, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+    int8 shiftCount;
+
+    shiftCount = 0;
+    if ( a < 0x10000 ) {
+        shiftCount += 16;
+        a <<= 16;
+    }
+    if ( a < 0x1000000 ) {
+        shiftCount += 8;
+        a <<= 8;
+    }
+    shiftCount += countLeadingZerosHigh[ a>>24 ];
+    return shiftCount;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the number of leading 0 bits before the most-significant 1 bit of
+| `a'.  If `a' is zero, 64 is returned.
+*----------------------------------------------------------------------------*/
+
+static int8 countLeadingZeros64( bits64 a )
+{
+    int8 shiftCount;
+
+    shiftCount = 0;
+    if ( a < ( (bits64) 1 )<<32 ) {
+        shiftCount += 32;
+    }
+    else {
+        a >>= 32;
+    }
+    shiftCount += countLeadingZeros32( a );
+    return shiftCount;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the 128-bit value formed by concatenating `a0' and `a1'
+| is equal to the 128-bit value formed by concatenating `b0' and `b1'.
+| Otherwise, returns 0.
+*----------------------------------------------------------------------------*/
+
+static inline flag eq128( bits64 a0, bits64 a1, bits64 b0, bits64 b1 )
+{
+
+    return ( a0 == b0 ) && ( a1 == b1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the 128-bit value formed by concatenating `a0' and `a1' is less
+| than or equal to the 128-bit value formed by concatenating `b0' and `b1'.
+| Otherwise, returns 0.
+*----------------------------------------------------------------------------*/
+
+static inline flag le128( bits64 a0, bits64 a1, bits64 b0, bits64 b1 )
+{
+
+    return ( a0 < b0 ) || ( ( a0 == b0 ) && ( a1 <= b1 ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the 128-bit value formed by concatenating `a0' and `a1' is less
+| than the 128-bit value formed by concatenating `b0' and `b1'.  Otherwise,
+| returns 0.
+*----------------------------------------------------------------------------*/
+
+static inline flag lt128( bits64 a0, bits64 a1, bits64 b0, bits64 b1 )
+{
+
+    return ( a0 < b0 ) || ( ( a0 == b0 ) && ( a1 < b1 ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the 128-bit value formed by concatenating `a0' and `a1' is
+| not equal to the 128-bit value formed by concatenating `b0' and `b1'.
+| Otherwise, returns 0.
+*----------------------------------------------------------------------------*/
+
+static inline flag ne128( bits64 a0, bits64 a1, bits64 b0, bits64 b1 )
+{
+
+    return ( a0 != b0 ) || ( a1 != b1 );
+
+}
+
+/*-----------------------------------------------------------------------------
+| Changes the sign of the extended double-precision floating-point value 'a'.
+| The operation is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static inline floatx80 floatx80_chs(floatx80 reg)
+{
+    reg.high ^= 0x8000;
+    return reg;
+}
+

--- a/softfloat/softfloat-specialize
+++ b/softfloat/softfloat-specialize
@@ -1,0 +1,470 @@
+
+/*============================================================================
+
+This C source fragment is part of the SoftFloat IEC/IEEE Floating-point
+Arithmetic Package, Release 2b.
+
+Written by John R. Hauser.  This work was made possible in part by the
+International Computer Science Institute, located at Suite 600, 1947 Center
+Street, Berkeley, California 94704.  Funding was partially provided by the
+National Science Foundation under grant MIP-9311980.  The original version
+of this code was written as part of a project to build a fixed-point vector
+processor in collaboration with the University of California at Berkeley,
+overseen by Profs. Nelson Morgan and John Wawrzynek.  More information
+is available through the Web page `http://www.cs.berkeley.edu/~jhauser/
+arithmetic/SoftFloat.html'.
+
+THIS SOFTWARE IS DISTRIBUTED AS IS, FOR FREE.  Although reasonable effort has
+been made to avoid it, THIS SOFTWARE MAY CONTAIN FAULTS THAT WILL AT TIMES
+RESULT IN INCORRECT BEHAVIOR.  USE OF THIS SOFTWARE IS RESTRICTED TO PERSONS
+AND ORGANIZATIONS WHO CAN AND WILL TAKE FULL RESPONSIBILITY FOR ALL LOSSES,
+COSTS, OR OTHER PROBLEMS THEY INCUR DUE TO THE SOFTWARE, AND WHO FURTHERMORE
+EFFECTIVELY INDEMNIFY JOHN HAUSER AND THE INTERNATIONAL COMPUTER SCIENCE
+INSTITUTE (possibly via similar legal warning) AGAINST ALL LOSSES, COSTS, OR
+OTHER PROBLEMS INCURRED BY THEIR CUSTOMERS AND CLIENTS DUE TO THE SOFTWARE.
+
+Derivative works are acceptable, even for commercial purposes, so long as
+(1) the source code for the derivative work includes prominent notice that
+the work is derivative, and (2) the source code includes prominent notice with
+these four paragraphs for those parts of this code that are retained.
+
+=============================================================================*/
+
+/*----------------------------------------------------------------------------
+| Underflow tininess-detection mode, statically initialized to default value.
+| (The declaration in `softfloat.h' must match the `int8' type here.)
+*----------------------------------------------------------------------------*/
+int8 float_detect_tininess = float_tininess_after_rounding;
+
+/*----------------------------------------------------------------------------
+| Raises the exceptions specified by `flags'.  Floating-point traps can be
+| defined here if desired.  It is currently not possible for such a trap to
+| substitute a result value.  If traps are not implemented, this routine
+| should be simply `float_exception_flags |= flags;'.
+*----------------------------------------------------------------------------*/
+
+void float_raise( int8 flags )
+{
+
+    float_exception_flags |= flags;
+
+}
+
+/*----------------------------------------------------------------------------
+| Internal canonical NaN format.
+*----------------------------------------------------------------------------*/
+typedef struct {
+    flag sign;
+    bits64 high, low;
+} commonNaNT;
+
+/*----------------------------------------------------------------------------
+| The pattern for a default generated single-precision NaN.
+*----------------------------------------------------------------------------*/
+#define float32_default_nan 0xFFFFFFFF
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the single-precision floating-point value `a' is a NaN;
+| otherwise returns 0.
+*----------------------------------------------------------------------------*/
+
+flag float32_is_nan( float32 a )
+{
+
+    return ( 0xFF000000 < (bits32) ( a<<1 ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the single-precision floating-point value `a' is a signaling
+| NaN; otherwise returns 0.
+*----------------------------------------------------------------------------*/
+
+flag float32_is_signaling_nan( float32 a )
+{
+
+    return ( ( ( a>>22 ) & 0x1FF ) == 0x1FE ) && ( a & 0x003FFFFF );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the single-precision floating-point NaN
+| `a' to the canonical NaN format.  If `a' is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+
+static commonNaNT float32ToCommonNaN( float32 a )
+{
+    commonNaNT z;
+
+    if ( float32_is_signaling_nan( a ) ) float_raise( float_flag_invalid );
+    z.sign = a>>31;
+    z.low = 0;
+    z.high = ( (bits64) a )<<41;
+    return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the canonical NaN `a' to the single-
+| precision floating-point format.
+*----------------------------------------------------------------------------*/
+
+static float32 commonNaNToFloat32( commonNaNT a )
+{
+
+    return ( ( (bits32) a.sign )<<31 ) | 0x7FC00000 | ( a.high>>41 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes two single-precision floating-point values `a' and `b', one of which
+| is a NaN, and returns the appropriate NaN result.  If either `a' or `b' is a
+| signaling NaN, the invalid exception is raised.
+*----------------------------------------------------------------------------*/
+
+static float32 propagateFloat32NaN( float32 a, float32 b )
+{
+    flag aIsNaN, aIsSignalingNaN, bIsNaN, bIsSignalingNaN;
+
+    aIsNaN = float32_is_nan( a );
+    aIsSignalingNaN = float32_is_signaling_nan( a );
+    bIsNaN = float32_is_nan( b );
+    bIsSignalingNaN = float32_is_signaling_nan( b );
+    a |= 0x00400000;
+    b |= 0x00400000;
+    if ( aIsSignalingNaN | bIsSignalingNaN ) float_raise( float_flag_invalid );
+    if ( aIsNaN ) {
+        return ( aIsSignalingNaN & bIsNaN ) ? b : a;
+    }
+    else {
+        return b;
+    }
+
+}
+
+/*----------------------------------------------------------------------------
+| The pattern for a default generated double-precision NaN.
+*----------------------------------------------------------------------------*/
+#define float64_default_nan LIT64( 0xFFFFFFFFFFFFFFFF )
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the double-precision floating-point value `a' is a NaN;
+| otherwise returns 0.
+*----------------------------------------------------------------------------*/
+
+flag float64_is_nan( float64 a )
+{
+
+    return ( LIT64( 0xFFE0000000000000 ) < (bits64) ( a<<1 ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the double-precision floating-point value `a' is a signaling
+| NaN; otherwise returns 0.
+*----------------------------------------------------------------------------*/
+
+flag float64_is_signaling_nan( float64 a )
+{
+
+    return
+           ( ( ( a>>51 ) & 0xFFF ) == 0xFFE )
+        && ( a & LIT64( 0x0007FFFFFFFFFFFF ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the double-precision floating-point NaN
+| `a' to the canonical NaN format.  If `a' is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+
+static commonNaNT float64ToCommonNaN( float64 a )
+{
+    commonNaNT z;
+
+    if ( float64_is_signaling_nan( a ) ) float_raise( float_flag_invalid );
+    z.sign = a>>63;
+    z.low = 0;
+    z.high = a<<12;
+    return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the canonical NaN `a' to the double-
+| precision floating-point format.
+*----------------------------------------------------------------------------*/
+
+static float64 commonNaNToFloat64( commonNaNT a )
+{
+
+    return
+          ( ( (bits64) a.sign )<<63 )
+        | LIT64( 0x7FF8000000000000 )
+        | ( a.high>>12 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes two double-precision floating-point values `a' and `b', one of which
+| is a NaN, and returns the appropriate NaN result.  If either `a' or `b' is a
+| signaling NaN, the invalid exception is raised.
+*----------------------------------------------------------------------------*/
+
+static float64 propagateFloat64NaN( float64 a, float64 b )
+{
+    flag aIsNaN, aIsSignalingNaN, bIsNaN, bIsSignalingNaN;
+
+    aIsNaN = float64_is_nan( a );
+    aIsSignalingNaN = float64_is_signaling_nan( a );
+    bIsNaN = float64_is_nan( b );
+    bIsSignalingNaN = float64_is_signaling_nan( b );
+    a |= LIT64( 0x0008000000000000 );
+    b |= LIT64( 0x0008000000000000 );
+    if ( aIsSignalingNaN | bIsSignalingNaN ) float_raise( float_flag_invalid );
+    if ( aIsNaN ) {
+        return ( aIsSignalingNaN & bIsNaN ) ? b : a;
+    }
+    else {
+        return b;
+    }
+
+}
+
+#ifdef FLOATX80
+
+/*----------------------------------------------------------------------------
+| The pattern for a default generated extended double-precision NaN.  The
+| `high' and `low' values hold the most- and least-significant bits,
+| respectively.
+*----------------------------------------------------------------------------*/
+#define floatx80_default_nan_high 0xFFFF
+#define floatx80_default_nan_low  LIT64( 0xFFFFFFFFFFFFFFFF )
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the extended double-precision floating-point value `a' is a
+| NaN; otherwise returns 0.
+*----------------------------------------------------------------------------*/
+
+flag floatx80_is_nan( floatx80 a )
+{
+
+    return ( ( a.high & 0x7FFF ) == 0x7FFF ) && (bits64) ( a.low<<1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the extended double-precision floating-point value `a' is a
+| signaling NaN; otherwise returns 0.
+*----------------------------------------------------------------------------*/
+
+flag floatx80_is_signaling_nan( floatx80 a )
+{
+    bits64 aLow;
+
+    aLow = a.low & ~ LIT64( 0x4000000000000000 );
+    return
+           ( ( a.high & 0x7FFF ) == 0x7FFF )
+        && (bits64) ( aLow<<1 )
+        && ( a.low == aLow );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the extended double-precision floating-
+| point NaN `a' to the canonical NaN format.  If `a' is a signaling NaN, the
+| invalid exception is raised.
+*----------------------------------------------------------------------------*/
+
+static commonNaNT floatx80ToCommonNaN( floatx80 a )
+{
+    commonNaNT z;
+
+    if ( floatx80_is_signaling_nan( a ) ) float_raise( float_flag_invalid );
+    z.sign = a.high>>15;
+    z.low = 0;
+    z.high = a.low<<1;
+    return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the canonical NaN `a' to the extended
+| double-precision floating-point format.
+*----------------------------------------------------------------------------*/
+
+static floatx80 commonNaNToFloatx80( commonNaNT a )
+{
+    floatx80 z;
+
+    z.low = LIT64( 0xC000000000000000 ) | ( a.high>>1 );
+    z.high = ( ( (bits16) a.sign )<<15 ) | 0x7FFF;
+    return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes two extended double-precision floating-point values `a' and `b', one
+| of which is a NaN, and returns the appropriate NaN result.  If either `a' or
+| `b' is a signaling NaN, the invalid exception is raised.
+*----------------------------------------------------------------------------*/
+
+floatx80 propagateFloatx80NaN( floatx80 a, floatx80 b )
+{
+    flag aIsNaN, aIsSignalingNaN, bIsNaN, bIsSignalingNaN;
+
+    aIsNaN = floatx80_is_nan( a );
+    aIsSignalingNaN = floatx80_is_signaling_nan( a );
+    bIsNaN = floatx80_is_nan( b );
+    bIsSignalingNaN = floatx80_is_signaling_nan( b );
+    a.low |= LIT64( 0xC000000000000000 );
+    b.low |= LIT64( 0xC000000000000000 );
+    if ( aIsSignalingNaN | bIsSignalingNaN ) float_raise( float_flag_invalid );
+    if ( aIsNaN ) {
+        return ( aIsSignalingNaN & bIsNaN ) ? b : a;
+    }
+    else {
+        return b;
+    }
+
+}
+
+#define EXP_BIAS 0x3FFF
+
+/*----------------------------------------------------------------------------
+| Returns the fraction bits of the extended double-precision floating-point
+| value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline bits64 extractFloatx80Frac( floatx80 a )
+{
+
+    return a.low;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the exponent bits of the extended double-precision floating-point
+| value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline int32 extractFloatx80Exp( floatx80 a )
+{
+
+    return a.high & 0x7FFF;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the sign bit of the extended double-precision floating-point value
+| `a'.
+*----------------------------------------------------------------------------*/
+
+static inline flag extractFloatx80Sign( floatx80 a )
+{
+
+    return a.high>>15;
+
+}
+
+#endif
+
+#ifdef FLOAT128
+
+/*----------------------------------------------------------------------------
+| The pattern for a default generated quadruple-precision NaN.  The `high' and
+| `low' values hold the most- and least-significant bits, respectively.
+*----------------------------------------------------------------------------*/
+#define float128_default_nan_high LIT64( 0xFFFFFFFFFFFFFFFF )
+#define float128_default_nan_low  LIT64( 0xFFFFFFFFFFFFFFFF )
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the quadruple-precision floating-point value `a' is a NaN;
+| otherwise returns 0.
+*----------------------------------------------------------------------------*/
+
+flag float128_is_nan( float128 a )
+{
+
+    return
+           ( LIT64( 0xFFFE000000000000 ) <= (bits64) ( a.high<<1 ) )
+        && ( a.low || ( a.high & LIT64( 0x0000FFFFFFFFFFFF ) ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the quadruple-precision floating-point value `a' is a
+| signaling NaN; otherwise returns 0.
+*----------------------------------------------------------------------------*/
+
+flag float128_is_signaling_nan( float128 a )
+{
+
+    return
+           ( ( ( a.high>>47 ) & 0xFFFF ) == 0xFFFE )
+        && ( a.low || ( a.high & LIT64( 0x00007FFFFFFFFFFF ) ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the quadruple-precision floating-point NaN
+| `a' to the canonical NaN format.  If `a' is a signaling NaN, the invalid
+| exception is raised.
+*----------------------------------------------------------------------------*/
+
+static commonNaNT float128ToCommonNaN( float128 a )
+{
+    commonNaNT z;
+
+    if ( float128_is_signaling_nan( a ) ) float_raise( float_flag_invalid );
+    z.sign = a.high>>63;
+    shortShift128Left( a.high, a.low, 16, &z.high, &z.low );
+    return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the canonical NaN `a' to the quadruple-
+| precision floating-point format.
+*----------------------------------------------------------------------------*/
+
+static float128 commonNaNToFloat128( commonNaNT a )
+{
+    float128 z;
+
+    shift128Right( a.high, a.low, 16, &z.high, &z.low );
+    z.high |= ( ( (bits64) a.sign )<<63 ) | LIT64( 0x7FFF800000000000 );
+    return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes two quadruple-precision floating-point values `a' and `b', one of
+| which is a NaN, and returns the appropriate NaN result.  If either `a' or
+| `b' is a signaling NaN, the invalid exception is raised.
+*----------------------------------------------------------------------------*/
+
+static float128 propagateFloat128NaN( float128 a, float128 b )
+{
+    flag aIsNaN, aIsSignalingNaN, bIsNaN, bIsSignalingNaN;
+
+    aIsNaN = float128_is_nan( a );
+    aIsSignalingNaN = float128_is_signaling_nan( a );
+    bIsNaN = float128_is_nan( b );
+    bIsSignalingNaN = float128_is_signaling_nan( b );
+    a.high |= LIT64( 0x0000800000000000 );
+    b.high |= LIT64( 0x0000800000000000 );
+    if ( aIsSignalingNaN | bIsSignalingNaN ) float_raise( float_flag_invalid );
+    if ( aIsNaN ) {
+        return ( aIsSignalingNaN & bIsNaN ) ? b : a;
+    }
+    else {
+        return b;
+    }
+
+}
+
+#endif
+

--- a/softfloat/softfloat.c
+++ b/softfloat/softfloat.c
@@ -1,0 +1,4940 @@
+
+/*============================================================================
+
+This C source file is part of the SoftFloat IEC/IEEE Floating-point Arithmetic
+Package, Release 2b.
+
+Written by John R. Hauser.  This work was made possible in part by the
+International Computer Science Institute, located at Suite 600, 1947 Center
+Street, Berkeley, California 94704.  Funding was partially provided by the
+National Science Foundation under grant MIP-9311980.  The original version
+of this code was written as part of a project to build a fixed-point vector
+processor in collaboration with the University of California at Berkeley,
+overseen by Profs. Nelson Morgan and John Wawrzynek.  More information
+is available through the Web page `http://www.cs.berkeley.edu/~jhauser/
+arithmetic/SoftFloat.html'.
+
+THIS SOFTWARE IS DISTRIBUTED AS IS, FOR FREE.  Although reasonable effort has
+been made to avoid it, THIS SOFTWARE MAY CONTAIN FAULTS THAT WILL AT TIMES
+RESULT IN INCORRECT BEHAVIOR.  USE OF THIS SOFTWARE IS RESTRICTED TO PERSONS
+AND ORGANIZATIONS WHO CAN AND WILL TAKE FULL RESPONSIBILITY FOR ALL LOSSES,
+COSTS, OR OTHER PROBLEMS THEY INCUR DUE TO THE SOFTWARE, AND WHO FURTHERMORE
+EFFECTIVELY INDEMNIFY JOHN HAUSER AND THE INTERNATIONAL COMPUTER SCIENCE
+INSTITUTE (possibly via similar legal warning) AGAINST ALL LOSSES, COSTS, OR
+OTHER PROBLEMS INCURRED BY THEIR CUSTOMERS AND CLIENTS DUE TO THE SOFTWARE.
+
+Derivative works are acceptable, even for commercial purposes, so long as
+(1) the source code for the derivative work includes prominent notice that
+the work is derivative, and (2) the source code includes prominent notice with
+these four paragraphs for those parts of this code that are retained.
+
+=============================================================================*/
+
+#include "../m68kcpu.h" // which includes softfloat.h after defining the basic types
+
+/*----------------------------------------------------------------------------
+| Floating-point rounding mode, extended double-precision rounding precision,
+| and exception flags.
+*----------------------------------------------------------------------------*/
+int8 float_exception_flags = 0;
+#ifdef FLOATX80
+int8 floatx80_rounding_precision = 80;
+#endif
+
+int8 float_rounding_mode = float_round_nearest_even;
+
+/*----------------------------------------------------------------------------
+| Functions and definitions to determine:  (1) whether tininess for underflow
+| is detected before or after rounding by default, (2) what (if anything)
+| happens when exceptions are raised, (3) how signaling NaNs are distinguished
+| from quiet NaNs, (4) the default generated quiet NaNs, and (5) how NaNs
+| are propagated from function inputs to output.  These details are target-
+| specific.
+*----------------------------------------------------------------------------*/
+#include "softfloat-specialize"
+
+/*----------------------------------------------------------------------------
+| Takes a 64-bit fixed-point value `absZ' with binary point between bits 6
+| and 7, and returns the properly rounded 32-bit integer corresponding to the
+| input.  If `zSign' is 1, the input is negated before being converted to an
+| integer.  Bit 63 of `absZ' must be zero.  Ordinarily, the fixed-point input
+| is simply rounded to an integer, with the inexact exception raised if the
+| input cannot be represented exactly as an integer.  However, if the fixed-
+| point input is too large, the invalid exception is raised and the largest
+| positive or negative integer is returned.
+*----------------------------------------------------------------------------*/
+
+static int32 roundAndPackInt32( flag zSign, bits64 absZ )
+{
+	int8 roundingMode;
+	flag roundNearestEven;
+	int8 roundIncrement, roundBits;
+	int32 z;
+
+	roundingMode = float_rounding_mode;
+	roundNearestEven = ( roundingMode == float_round_nearest_even );
+	roundIncrement = 0x40;
+	if ( ! roundNearestEven ) {
+		if ( roundingMode == float_round_to_zero ) {
+			roundIncrement = 0;
+		}
+		else {
+			roundIncrement = 0x7F;
+			if ( zSign ) {
+				if ( roundingMode == float_round_up ) roundIncrement = 0;
+			}
+			else {
+				if ( roundingMode == float_round_down ) roundIncrement = 0;
+			}
+		}
+	}
+	roundBits = absZ & 0x7F;
+	absZ = ( absZ + roundIncrement )>>7;
+	absZ &= ~ ( ( ( roundBits ^ 0x40 ) == 0 ) & roundNearestEven );
+	z = absZ;
+	if ( zSign ) z = - z;
+	if ( ( absZ>>32 ) || ( z && ( ( z < 0 ) ^ zSign ) ) ) {
+		float_raise( float_flag_invalid );
+		return zSign ? (sbits32) 0x80000000 : 0x7FFFFFFF;
+	}
+	if ( roundBits ) float_exception_flags |= float_flag_inexact;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes the 128-bit fixed-point value formed by concatenating `absZ0' and
+| `absZ1', with binary point between bits 63 and 64 (between the input words),
+| and returns the properly rounded 64-bit integer corresponding to the input.
+| If `zSign' is 1, the input is negated before being converted to an integer.
+| Ordinarily, the fixed-point input is simply rounded to an integer, with
+| the inexact exception raised if the input cannot be represented exactly as
+| an integer.  However, if the fixed-point input is too large, the invalid
+| exception is raised and the largest positive or negative integer is
+| returned.
+*----------------------------------------------------------------------------*/
+
+static int64 roundAndPackInt64( flag zSign, bits64 absZ0, bits64 absZ1 )
+{
+	int8 roundingMode;
+	flag roundNearestEven, increment;
+	int64 z;
+
+	roundingMode = float_rounding_mode;
+	roundNearestEven = ( roundingMode == float_round_nearest_even );
+	increment = ( (sbits64) absZ1 < 0 );
+	if ( ! roundNearestEven ) {
+		if ( roundingMode == float_round_to_zero ) {
+			increment = 0;
+		}
+		else {
+			if ( zSign ) {
+				increment = ( roundingMode == float_round_down ) && absZ1;
+			}
+			else {
+				increment = ( roundingMode == float_round_up ) && absZ1;
+			}
+		}
+	}
+	if ( increment ) {
+		++absZ0;
+		if ( absZ0 == 0 ) goto overflow;
+		absZ0 &= ~ ( ( (bits64) ( absZ1<<1 ) == 0 ) & roundNearestEven );
+	}
+	z = absZ0;
+	if ( zSign ) z = - z;
+	if ( z && ( ( z < 0 ) ^ zSign ) ) {
+	overflow:
+		float_raise( float_flag_invalid );
+		return
+				zSign ? (sbits64) LIT64( 0x8000000000000000 )
+			: LIT64( 0x7FFFFFFFFFFFFFFF );
+	}
+	if ( absZ1 ) float_exception_flags |= float_flag_inexact;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the fraction bits of the single-precision floating-point value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline bits32 extractFloat32Frac( float32 a )
+{
+	return a & 0x007FFFFF;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the exponent bits of the single-precision floating-point value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline int16 extractFloat32Exp( float32 a )
+{
+	return ( a>>23 ) & 0xFF;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the sign bit of the single-precision floating-point value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline flag extractFloat32Sign( float32 a )
+{
+	return a>>31;
+
+}
+
+/*----------------------------------------------------------------------------
+| Normalizes the subnormal single-precision floating-point value represented
+| by the denormalized significand `aSig'.  The normalized exponent and
+| significand are stored at the locations pointed to by `zExpPtr' and
+| `zSigPtr', respectively.
+*----------------------------------------------------------------------------*/
+
+static void
+	normalizeFloat32Subnormal( bits32 aSig, int16 *zExpPtr, bits32 *zSigPtr )
+{
+	int8 shiftCount;
+
+	shiftCount = countLeadingZeros32( aSig ) - 8;
+	*zSigPtr = aSig<<shiftCount;
+	*zExpPtr = 1 - shiftCount;
+
+}
+
+/*----------------------------------------------------------------------------
+| Packs the sign `zSign', exponent `zExp', and significand `zSig' into a
+| single-precision floating-point value, returning the result.  After being
+| shifted into the proper positions, the three fields are simply added
+| together to form the result.  This means that any integer portion of `zSig'
+| will be added into the exponent.  Since a properly normalized significand
+| will have an integer portion equal to 1, the `zExp' input should be 1 less
+| than the desired result exponent whenever `zSig' is a complete, normalized
+| significand.
+*----------------------------------------------------------------------------*/
+
+static inline float32 packFloat32( flag zSign, int16 zExp, bits32 zSig )
+{
+	return ( ( (bits32) zSign )<<31 ) + ( ( (bits32) zExp )<<23 ) + zSig;
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes an abstract floating-point value having sign `zSign', exponent `zExp',
+| and significand `zSig', and returns the proper single-precision floating-
+| point value corresponding to the abstract input.  Ordinarily, the abstract
+| value is simply rounded and packed into the single-precision format, with
+| the inexact exception raised if the abstract input cannot be represented
+| exactly.  However, if the abstract value is too large, the overflow and
+| inexact exceptions are raised and an infinity or maximal finite value is
+| returned.  If the abstract value is too small, the input value is rounded to
+| a subnormal number, and the underflow and inexact exceptions are raised if
+| the abstract input cannot be represented exactly as a subnormal single-
+| precision floating-point number.
+|     The input significand `zSig' has its binary point between bits 30
+| and 29, which is 7 bits to the left of the usual location.  This shifted
+| significand must be normalized or smaller.  If `zSig' is not normalized,
+| `zExp' must be 0; in that case, the result returned is a subnormal number,
+| and it must not require rounding.  In the usual case that `zSig' is
+| normalized, `zExp' must be 1 less than the ``true'' floating-point exponent.
+| The handling of underflow and overflow follows the IEC/IEEE Standard for
+| Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static float32 roundAndPackFloat32( flag zSign, int16 zExp, bits32 zSig )
+{
+	int8 roundingMode;
+	flag roundNearestEven;
+	int8 roundIncrement, roundBits;
+	flag isTiny;
+
+	roundingMode = float_rounding_mode;
+	roundNearestEven = ( roundingMode == float_round_nearest_even );
+	roundIncrement = 0x40;
+	if ( ! roundNearestEven ) {
+		if ( roundingMode == float_round_to_zero ) {
+			roundIncrement = 0;
+		}
+		else {
+			roundIncrement = 0x7F;
+			if ( zSign ) {
+				if ( roundingMode == float_round_up ) roundIncrement = 0;
+			}
+			else {
+				if ( roundingMode == float_round_down ) roundIncrement = 0;
+			}
+		}
+	}
+	roundBits = zSig & 0x7F;
+	if ( 0xFD <= (bits16) zExp ) {
+		if (    ( 0xFD < zExp )
+				|| (    ( zExp == 0xFD )
+					&& ( (sbits32) ( zSig + roundIncrement ) < 0 ) )
+			) {
+			float_raise( float_flag_overflow | float_flag_inexact );
+			return packFloat32( zSign, 0xFF, 0 ) - ( roundIncrement == 0 );
+		}
+		if ( zExp < 0 ) {
+			isTiny =
+					( float_detect_tininess == float_tininess_before_rounding )
+				|| ( zExp < -1 )
+				|| ( zSig + roundIncrement < 0x80000000 );
+			shift32RightJamming( zSig, - zExp, &zSig );
+			zExp = 0;
+			roundBits = zSig & 0x7F;
+			if ( isTiny && roundBits ) float_raise( float_flag_underflow );
+		}
+	}
+	if ( roundBits ) float_exception_flags |= float_flag_inexact;
+	zSig = ( zSig + roundIncrement )>>7;
+	zSig &= ~ ( ( ( roundBits ^ 0x40 ) == 0 ) & roundNearestEven );
+	if ( zSig == 0 ) zExp = 0;
+	return packFloat32( zSign, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes an abstract floating-point value having sign `zSign', exponent `zExp',
+| and significand `zSig', and returns the proper single-precision floating-
+| point value corresponding to the abstract input.  This routine is just like
+| `roundAndPackFloat32' except that `zSig' does not have to be normalized.
+| Bit 31 of `zSig' must be zero, and `zExp' must be 1 less than the ``true''
+| floating-point exponent.
+*----------------------------------------------------------------------------*/
+
+static float32
+	normalizeRoundAndPackFloat32( flag zSign, int16 zExp, bits32 zSig )
+{
+	int8 shiftCount;
+
+	shiftCount = countLeadingZeros32( zSig ) - 1;
+	return roundAndPackFloat32( zSign, zExp - shiftCount, zSig<<shiftCount );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the fraction bits of the double-precision floating-point value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline bits64 extractFloat64Frac( float64 a )
+{
+	return a & LIT64( 0x000FFFFFFFFFFFFF );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the exponent bits of the double-precision floating-point value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline int16 extractFloat64Exp( float64 a )
+{
+	return ( a>>52 ) & 0x7FF;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the sign bit of the double-precision floating-point value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline flag extractFloat64Sign( float64 a )
+{
+	return a>>63;
+
+}
+
+/*----------------------------------------------------------------------------
+| Normalizes the subnormal double-precision floating-point value represented
+| by the denormalized significand `aSig'.  The normalized exponent and
+| significand are stored at the locations pointed to by `zExpPtr' and
+| `zSigPtr', respectively.
+*----------------------------------------------------------------------------*/
+
+static void
+	normalizeFloat64Subnormal( bits64 aSig, int16 *zExpPtr, bits64 *zSigPtr )
+{
+	int8 shiftCount;
+
+	shiftCount = countLeadingZeros64( aSig ) - 11;
+	*zSigPtr = aSig<<shiftCount;
+	*zExpPtr = 1 - shiftCount;
+
+}
+
+/*----------------------------------------------------------------------------
+| Packs the sign `zSign', exponent `zExp', and significand `zSig' into a
+| double-precision floating-point value, returning the result.  After being
+| shifted into the proper positions, the three fields are simply added
+| together to form the result.  This means that any integer portion of `zSig'
+| will be added into the exponent.  Since a properly normalized significand
+| will have an integer portion equal to 1, the `zExp' input should be 1 less
+| than the desired result exponent whenever `zSig' is a complete, normalized
+| significand.
+*----------------------------------------------------------------------------*/
+
+static inline float64 packFloat64( flag zSign, int16 zExp, bits64 zSig )
+{
+	return ( ( (bits64) zSign )<<63 ) + ( ( (bits64) zExp )<<52 ) + zSig;
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes an abstract floating-point value having sign `zSign', exponent `zExp',
+| and significand `zSig', and returns the proper double-precision floating-
+| point value corresponding to the abstract input.  Ordinarily, the abstract
+| value is simply rounded and packed into the double-precision format, with
+| the inexact exception raised if the abstract input cannot be represented
+| exactly.  However, if the abstract value is too large, the overflow and
+| inexact exceptions are raised and an infinity or maximal finite value is
+| returned.  If the abstract value is too small, the input value is rounded
+| to a subnormal number, and the underflow and inexact exceptions are raised
+| if the abstract input cannot be represented exactly as a subnormal double-
+| precision floating-point number.
+|     The input significand `zSig' has its binary point between bits 62
+| and 61, which is 10 bits to the left of the usual location.  This shifted
+| significand must be normalized or smaller.  If `zSig' is not normalized,
+| `zExp' must be 0; in that case, the result returned is a subnormal number,
+| and it must not require rounding.  In the usual case that `zSig' is
+| normalized, `zExp' must be 1 less than the ``true'' floating-point exponent.
+| The handling of underflow and overflow follows the IEC/IEEE Standard for
+| Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static float64 roundAndPackFloat64( flag zSign, int16 zExp, bits64 zSig )
+{
+	int8 roundingMode;
+	flag roundNearestEven;
+	int16 roundIncrement, roundBits;
+	flag isTiny;
+
+	roundingMode = float_rounding_mode;
+	roundNearestEven = ( roundingMode == float_round_nearest_even );
+	roundIncrement = 0x200;
+	if ( ! roundNearestEven ) {
+		if ( roundingMode == float_round_to_zero ) {
+			roundIncrement = 0;
+		}
+		else {
+			roundIncrement = 0x3FF;
+			if ( zSign ) {
+				if ( roundingMode == float_round_up ) roundIncrement = 0;
+			}
+			else {
+				if ( roundingMode == float_round_down ) roundIncrement = 0;
+			}
+		}
+	}
+	roundBits = zSig & 0x3FF;
+	if ( 0x7FD <= (bits16) zExp ) {
+		if (    ( 0x7FD < zExp )
+				|| (    ( zExp == 0x7FD )
+					&& ( (sbits64) ( zSig + roundIncrement ) < 0 ) )
+			) {
+			float_raise( float_flag_overflow | float_flag_inexact );
+			return packFloat64( zSign, 0x7FF, 0 ) - ( roundIncrement == 0 );
+		}
+		if ( zExp < 0 ) {
+			isTiny =
+					( float_detect_tininess == float_tininess_before_rounding )
+				|| ( zExp < -1 )
+				|| ( zSig + roundIncrement < LIT64( 0x8000000000000000 ) );
+			shift64RightJamming( zSig, - zExp, &zSig );
+			zExp = 0;
+			roundBits = zSig & 0x3FF;
+			if ( isTiny && roundBits ) float_raise( float_flag_underflow );
+		}
+	}
+	if ( roundBits ) float_exception_flags |= float_flag_inexact;
+	zSig = ( zSig + roundIncrement )>>10;
+	zSig &= ~ ( ( ( roundBits ^ 0x200 ) == 0 ) & roundNearestEven );
+	if ( zSig == 0 ) zExp = 0;
+	return packFloat64( zSign, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes an abstract floating-point value having sign `zSign', exponent `zExp',
+| and significand `zSig', and returns the proper double-precision floating-
+| point value corresponding to the abstract input.  This routine is just like
+| `roundAndPackFloat64' except that `zSig' does not have to be normalized.
+| Bit 63 of `zSig' must be zero, and `zExp' must be 1 less than the ``true''
+| floating-point exponent.
+*----------------------------------------------------------------------------*/
+
+static float64
+	normalizeRoundAndPackFloat64( flag zSign, int16 zExp, bits64 zSig )
+{
+	int8 shiftCount;
+
+	shiftCount = countLeadingZeros64( zSig ) - 1;
+	return roundAndPackFloat64( zSign, zExp - shiftCount, zSig<<shiftCount );
+
+}
+
+#ifdef FLOATX80
+
+/*----------------------------------------------------------------------------
+| Normalizes the subnormal extended double-precision floating-point value
+| represented by the denormalized significand `aSig'.  The normalized exponent
+| and significand are stored at the locations pointed to by `zExpPtr' and
+| `zSigPtr', respectively.
+*----------------------------------------------------------------------------*/
+
+static void
+	normalizeFloatx80Subnormal( bits64 aSig, int32 *zExpPtr, bits64 *zSigPtr )
+{
+	int8 shiftCount;
+
+	shiftCount = countLeadingZeros64( aSig );
+	*zSigPtr = aSig<<shiftCount;
+	*zExpPtr = 1 - shiftCount;
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes an abstract floating-point value having sign `zSign', exponent `zExp',
+| and extended significand formed by the concatenation of `zSig0' and `zSig1',
+| and returns the proper extended double-precision floating-point value
+| corresponding to the abstract input.  Ordinarily, the abstract value is
+| rounded and packed into the extended double-precision format, with the
+| inexact exception raised if the abstract input cannot be represented
+| exactly.  However, if the abstract value is too large, the overflow and
+| inexact exceptions are raised and an infinity or maximal finite value is
+| returned.  If the abstract value is too small, the input value is rounded to
+| a subnormal number, and the underflow and inexact exceptions are raised if
+| the abstract input cannot be represented exactly as a subnormal extended
+| double-precision floating-point number.
+|     If `roundingPrecision' is 32 or 64, the result is rounded to the same
+| number of bits as single or double precision, respectively.  Otherwise, the
+| result is rounded to the full precision of the extended double-precision
+| format.
+|     The input significand must be normalized or smaller.  If the input
+| significand is not normalized, `zExp' must be 0; in that case, the result
+| returned is a subnormal number, and it must not require rounding.  The
+| handling of underflow and overflow follows the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+// roundAndPackFloatx80 is now also used in fyl2x.c
+
+/* static */ floatx80
+	roundAndPackFloatx80(
+		int8 roundingPrecision, flag zSign, int32 zExp, bits64 zSig0, bits64 zSig1
+	)
+{
+	int8 roundingMode;
+	flag roundNearestEven, increment, isTiny;
+	int64 roundIncrement, roundMask, roundBits;
+
+	roundingMode = float_rounding_mode;
+	roundNearestEven = ( roundingMode == float_round_nearest_even );
+	if ( roundingPrecision == 80 ) goto precision80;
+	if ( roundingPrecision == 64 ) {
+		roundIncrement = LIT64( 0x0000000000000400 );
+		roundMask = LIT64( 0x00000000000007FF );
+	}
+	else if ( roundingPrecision == 32 ) {
+		roundIncrement = LIT64( 0x0000008000000000 );
+		roundMask = LIT64( 0x000000FFFFFFFFFF );
+	}
+	else {
+		goto precision80;
+	}
+	zSig0 |= ( zSig1 != 0 );
+	if ( ! roundNearestEven ) {
+		if ( roundingMode == float_round_to_zero ) {
+			roundIncrement = 0;
+		}
+		else {
+			roundIncrement = roundMask;
+			if ( zSign ) {
+				if ( roundingMode == float_round_up ) roundIncrement = 0;
+			}
+			else {
+				if ( roundingMode == float_round_down ) roundIncrement = 0;
+			}
+		}
+	}
+	roundBits = zSig0 & roundMask;
+	if ( 0x7FFD <= (bits32) ( zExp - 1 ) ) {
+		if (    ( 0x7FFE < zExp )
+				|| ( ( zExp == 0x7FFE ) && ( zSig0 + roundIncrement < zSig0 ) )
+			) {
+			goto overflow;
+		}
+		if ( zExp <= 0 ) {
+			isTiny =
+					( float_detect_tininess == float_tininess_before_rounding )
+				|| ( zExp < 0 )
+				|| ( zSig0 <= zSig0 + roundIncrement );
+			shift64RightJamming( zSig0, 1 - zExp, &zSig0 );
+			zExp = 0;
+			roundBits = zSig0 & roundMask;
+			if ( isTiny && roundBits ) float_raise( float_flag_underflow );
+			if ( roundBits ) float_exception_flags |= float_flag_inexact;
+			zSig0 += roundIncrement;
+			if ( (sbits64) zSig0 < 0 ) zExp = 1;
+			roundIncrement = roundMask + 1;
+			if ( roundNearestEven && ( roundBits<<1 == roundIncrement ) ) {
+				roundMask |= roundIncrement;
+			}
+			zSig0 &= ~ roundMask;
+			return packFloatx80( zSign, zExp, zSig0 );
+		}
+	}
+	if ( roundBits ) float_exception_flags |= float_flag_inexact;
+	zSig0 += roundIncrement;
+	if ( zSig0 < roundIncrement ) {
+		++zExp;
+		zSig0 = LIT64( 0x8000000000000000 );
+	}
+	roundIncrement = roundMask + 1;
+	if ( roundNearestEven && ( roundBits<<1 == roundIncrement ) ) {
+		roundMask |= roundIncrement;
+	}
+	zSig0 &= ~ roundMask;
+	if ( zSig0 == 0 ) zExp = 0;
+	return packFloatx80( zSign, zExp, zSig0 );
+	precision80:
+	increment = ( (sbits64) zSig1 < 0 );
+	if ( ! roundNearestEven ) {
+		if ( roundingMode == float_round_to_zero ) {
+			increment = 0;
+		}
+		else {
+			if ( zSign ) {
+				increment = ( roundingMode == float_round_down ) && zSig1;
+			}
+			else {
+				increment = ( roundingMode == float_round_up ) && zSig1;
+			}
+		}
+	}
+	if ( 0x7FFD <= (bits32) ( zExp - 1 ) ) {
+		if (    ( 0x7FFE < zExp )
+				|| (    ( zExp == 0x7FFE )
+					&& ( zSig0 == LIT64( 0xFFFFFFFFFFFFFFFF ) )
+					&& increment
+				)
+			) {
+			roundMask = 0;
+	overflow:
+			float_raise( float_flag_overflow | float_flag_inexact );
+			if (    ( roundingMode == float_round_to_zero )
+					|| ( zSign && ( roundingMode == float_round_up ) )
+					|| ( ! zSign && ( roundingMode == float_round_down ) )
+				) {
+				return packFloatx80( zSign, 0x7FFE, ~ roundMask );
+			}
+			return packFloatx80( zSign, 0x7FFF, LIT64( 0x8000000000000000 ) );
+		}
+		if ( zExp <= 0 ) {
+			isTiny =
+					( float_detect_tininess == float_tininess_before_rounding )
+				|| ( zExp < 0 )
+				|| ! increment
+				|| ( zSig0 < LIT64( 0xFFFFFFFFFFFFFFFF ) );
+			shift64ExtraRightJamming( zSig0, zSig1, 1 - zExp, &zSig0, &zSig1 );
+			zExp = 0;
+			if ( isTiny && zSig1 ) float_raise( float_flag_underflow );
+			if ( zSig1 ) float_exception_flags |= float_flag_inexact;
+			if ( roundNearestEven ) {
+				increment = ( (sbits64) zSig1 < 0 );
+			}
+			else {
+				if ( zSign ) {
+					increment = ( roundingMode == float_round_down ) && zSig1;
+				}
+				else {
+					increment = ( roundingMode == float_round_up ) && zSig1;
+				}
+			}
+			if ( increment ) {
+				++zSig0;
+				zSig0 &=
+					~ ( ( (bits64) ( zSig1<<1 ) == 0 ) & roundNearestEven );
+				if ( (sbits64) zSig0 < 0 ) zExp = 1;
+			}
+			return packFloatx80( zSign, zExp, zSig0 );
+		}
+	}
+	if ( zSig1 ) float_exception_flags |= float_flag_inexact;
+	if ( increment ) {
+		++zSig0;
+		if ( zSig0 == 0 ) {
+			++zExp;
+			zSig0 = LIT64( 0x8000000000000000 );
+		}
+		else {
+			zSig0 &= ~ ( ( (bits64) ( zSig1<<1 ) == 0 ) & roundNearestEven );
+		}
+	}
+	else {
+		if ( zSig0 == 0 ) zExp = 0;
+	}
+	return packFloatx80( zSign, zExp, zSig0 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes an abstract floating-point value having sign `zSign', exponent
+| `zExp', and significand formed by the concatenation of `zSig0' and `zSig1',
+| and returns the proper extended double-precision floating-point value
+| corresponding to the abstract input.  This routine is just like
+| `roundAndPackFloatx80' except that the input significand does not have to be
+| normalized.
+*----------------------------------------------------------------------------*/
+
+static floatx80
+	normalizeRoundAndPackFloatx80(
+		int8 roundingPrecision, flag zSign, int32 zExp, bits64 zSig0, bits64 zSig1
+	)
+{
+	int8 shiftCount;
+
+	if ( zSig0 == 0 ) {
+		zSig0 = zSig1;
+		zSig1 = 0;
+		zExp -= 64;
+	}
+	shiftCount = countLeadingZeros64( zSig0 );
+	shortShift128Left( zSig0, zSig1, shiftCount, &zSig0, &zSig1 );
+	zExp -= shiftCount;
+	return
+		roundAndPackFloatx80( roundingPrecision, zSign, zExp, zSig0, zSig1 );
+
+}
+
+#endif
+
+#ifdef FLOAT128
+
+/*----------------------------------------------------------------------------
+| Returns the least-significant 64 fraction bits of the quadruple-precision
+| floating-point value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline bits64 extractFloat128Frac1( float128 a )
+{
+	return a.low;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the most-significant 48 fraction bits of the quadruple-precision
+| floating-point value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline bits64 extractFloat128Frac0( float128 a )
+{
+	return a.high & LIT64( 0x0000FFFFFFFFFFFF );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the exponent bits of the quadruple-precision floating-point value
+| `a'.
+*----------------------------------------------------------------------------*/
+
+static inline int32 extractFloat128Exp( float128 a )
+{
+	return ( a.high>>48 ) & 0x7FFF;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the sign bit of the quadruple-precision floating-point value `a'.
+*----------------------------------------------------------------------------*/
+
+static inline flag extractFloat128Sign( float128 a )
+{
+	return a.high>>63;
+
+}
+
+/*----------------------------------------------------------------------------
+| Normalizes the subnormal quadruple-precision floating-point value
+| represented by the denormalized significand formed by the concatenation of
+| `aSig0' and `aSig1'.  The normalized exponent is stored at the location
+| pointed to by `zExpPtr'.  The most significant 49 bits of the normalized
+| significand are stored at the location pointed to by `zSig0Ptr', and the
+| least significant 64 bits of the normalized significand are stored at the
+| location pointed to by `zSig1Ptr'.
+*----------------------------------------------------------------------------*/
+
+static void
+	normalizeFloat128Subnormal(
+		bits64 aSig0,
+		bits64 aSig1,
+		int32 *zExpPtr,
+		bits64 *zSig0Ptr,
+		bits64 *zSig1Ptr
+	)
+{
+	int8 shiftCount;
+
+	if ( aSig0 == 0 ) {
+		shiftCount = countLeadingZeros64( aSig1 ) - 15;
+		if ( shiftCount < 0 ) {
+			*zSig0Ptr = aSig1>>( - shiftCount );
+			*zSig1Ptr = aSig1<<( shiftCount & 63 );
+		}
+		else {
+			*zSig0Ptr = aSig1<<shiftCount;
+			*zSig1Ptr = 0;
+		}
+		*zExpPtr = - shiftCount - 63;
+	}
+	else {
+		shiftCount = countLeadingZeros64( aSig0 ) - 15;
+		shortShift128Left( aSig0, aSig1, shiftCount, zSig0Ptr, zSig1Ptr );
+		*zExpPtr = 1 - shiftCount;
+	}
+
+}
+
+#endif
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the 32-bit two's complement integer `a'
+| to the single-precision floating-point format.  The conversion is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 int32_to_float32( int32 a )
+{
+	flag zSign;
+
+	if ( a == 0 ) return 0;
+	if ( a == (sbits32) 0x80000000 ) return packFloat32( 1, 0x9E, 0 );
+	zSign = ( a < 0 );
+	return normalizeRoundAndPackFloat32( zSign, 0x9C, zSign ? - a : a );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the 32-bit two's complement integer `a'
+| to the double-precision floating-point format.  The conversion is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 int32_to_float64( int32 a )
+{
+	flag zSign;
+	uint32 absA;
+	int8 shiftCount;
+	bits64 zSig;
+
+	if ( a == 0 ) return 0;
+	zSign = ( a < 0 );
+	absA = zSign ? - a : a;
+	shiftCount = countLeadingZeros32( absA ) + 21;
+	zSig = absA;
+	return packFloat64( zSign, 0x432 - shiftCount, zSig<<shiftCount );
+
+}
+
+#ifdef FLOATX80
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the 32-bit two's complement integer `a'
+| to the extended double-precision floating-point format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 int32_to_floatx80( int32 a )
+{
+	flag zSign;
+	uint32 absA;
+	int8 shiftCount;
+	bits64 zSig;
+
+	if ( a == 0 ) return packFloatx80( 0, 0, 0 );
+	zSign = ( a < 0 );
+	absA = zSign ? - a : a;
+	shiftCount = countLeadingZeros32( absA ) + 32;
+	zSig = absA;
+	return packFloatx80( zSign, 0x403E - shiftCount, zSig<<shiftCount );
+
+}
+
+#endif
+
+#ifdef FLOAT128
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the 32-bit two's complement integer `a' to
+| the quadruple-precision floating-point format.  The conversion is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 int32_to_float128( int32 a )
+{
+	flag zSign;
+	uint32 absA;
+	int8 shiftCount;
+	bits64 zSig0;
+
+	if ( a == 0 ) return packFloat128( 0, 0, 0, 0 );
+	zSign = ( a < 0 );
+	absA = zSign ? - a : a;
+	shiftCount = countLeadingZeros32( absA ) + 17;
+	zSig0 = absA;
+	return packFloat128( zSign, 0x402E - shiftCount, zSig0<<shiftCount, 0 );
+
+}
+
+#endif
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the 64-bit two's complement integer `a'
+| to the single-precision floating-point format.  The conversion is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 int64_to_float32( int64 a )
+{
+	flag zSign;
+	uint64 absA;
+	int8 shiftCount;
+//    bits32 zSig;
+
+	if ( a == 0 ) return 0;
+	zSign = ( a < 0 );
+	absA = zSign ? - a : a;
+	shiftCount = countLeadingZeros64( absA ) - 40;
+	if ( 0 <= shiftCount ) {
+		return packFloat32( zSign, 0x95 - shiftCount, absA<<shiftCount );
+	}
+	else {
+		shiftCount += 7;
+		if ( shiftCount < 0 ) {
+			shift64RightJamming( absA, - shiftCount, &absA );
+		}
+		else {
+			absA <<= shiftCount;
+		}
+		return roundAndPackFloat32( zSign, 0x9C - shiftCount, absA );
+	}
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the 64-bit two's complement integer `a'
+| to the double-precision floating-point format.  The conversion is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 int64_to_float64( int64 a )
+{
+	flag zSign;
+
+	if ( a == 0 ) return 0;
+	if ( a == (sbits64) LIT64( 0x8000000000000000 ) ) {
+		return packFloat64( 1, 0x43E, 0 );
+	}
+	zSign = ( a < 0 );
+	return normalizeRoundAndPackFloat64( zSign, 0x43C, zSign ? - a : a );
+
+}
+
+#ifdef FLOATX80
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the 64-bit two's complement integer `a'
+| to the extended double-precision floating-point format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 int64_to_floatx80( int64 a )
+{
+	flag zSign;
+	uint64 absA;
+	int8 shiftCount;
+
+	if ( a == 0 ) return packFloatx80( 0, 0, 0 );
+	zSign = ( a < 0 );
+	absA = zSign ? - a : a;
+	shiftCount = countLeadingZeros64( absA );
+	return packFloatx80( zSign, 0x403E - shiftCount, absA<<shiftCount );
+
+}
+
+#endif
+
+#ifdef FLOAT128
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the 64-bit two's complement integer `a' to
+| the quadruple-precision floating-point format.  The conversion is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 int64_to_float128( int64 a )
+{
+	flag zSign;
+	uint64 absA;
+	int8 shiftCount;
+	int32 zExp;
+	bits64 zSig0, zSig1;
+
+	if ( a == 0 ) return packFloat128( 0, 0, 0, 0 );
+	zSign = ( a < 0 );
+	absA = zSign ? - a : a;
+	shiftCount = countLeadingZeros64( absA ) + 49;
+	zExp = 0x406E - shiftCount;
+	if ( 64 <= shiftCount ) {
+		zSig1 = 0;
+		zSig0 = absA;
+		shiftCount -= 64;
+	}
+	else {
+		zSig1 = absA;
+		zSig0 = 0;
+	}
+	shortShift128Left( zSig0, zSig1, shiftCount, &zSig0, &zSig1 );
+	return packFloat128( zSign, zExp, zSig0, zSig1 );
+
+}
+
+#endif
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the single-precision floating-point value
+| `a' to the 32-bit two's complement integer format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic---which means in particular that the conversion is rounded
+| according to the current rounding mode.  If `a' is a NaN, the largest
+| positive integer is returned.  Otherwise, if the conversion overflows, the
+| largest integer with the same sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int32 float32_to_int32( float32 a )
+{
+	flag aSign;
+	int16 aExp, shiftCount;
+	bits32 aSig;
+	bits64 aSig64;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	if ( ( aExp == 0xFF ) && aSig ) aSign = 0;
+	if ( aExp ) aSig |= 0x00800000;
+	shiftCount = 0xAF - aExp;
+	aSig64 = aSig;
+	aSig64 <<= 32;
+	if ( 0 < shiftCount ) shift64RightJamming( aSig64, shiftCount, &aSig64 );
+	return roundAndPackInt32( aSign, aSig64 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the single-precision floating-point value
+| `a' to the 32-bit two's complement integer format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic, except that the conversion is always rounded toward zero.
+| If `a' is a NaN, the largest positive integer is returned.  Otherwise, if
+| the conversion overflows, the largest integer with the same sign as `a' is
+| returned.
+*----------------------------------------------------------------------------*/
+
+int32 float32_to_int32_round_to_zero( float32 a )
+{
+	flag aSign;
+	int16 aExp, shiftCount;
+	bits32 aSig;
+	int32 z;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	shiftCount = aExp - 0x9E;
+	if ( 0 <= shiftCount ) {
+		if ( a != 0xCF000000 ) {
+			float_raise( float_flag_invalid );
+			if ( ! aSign || ( ( aExp == 0xFF ) && aSig ) ) return 0x7FFFFFFF;
+		}
+		return (sbits32) 0x80000000;
+	}
+	else if ( aExp <= 0x7E ) {
+		if ( aExp | aSig ) float_exception_flags |= float_flag_inexact;
+		return 0;
+	}
+	aSig = ( aSig | 0x00800000 )<<8;
+	z = aSig>>( - shiftCount );
+	if ( (bits32) ( aSig<<( shiftCount & 31 ) ) ) {
+		float_exception_flags |= float_flag_inexact;
+	}
+	if ( aSign ) z = - z;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the single-precision floating-point value
+| `a' to the 64-bit two's complement integer format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic---which means in particular that the conversion is rounded
+| according to the current rounding mode.  If `a' is a NaN, the largest
+| positive integer is returned.  Otherwise, if the conversion overflows, the
+| largest integer with the same sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int64 float32_to_int64( float32 a )
+{
+	flag aSign;
+	int16 aExp, shiftCount;
+	bits32 aSig;
+	bits64 aSig64, aSigExtra;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	shiftCount = 0xBE - aExp;
+	if ( shiftCount < 0 ) {
+		float_raise( float_flag_invalid );
+		if ( ! aSign || ( ( aExp == 0xFF ) && aSig ) ) {
+			return LIT64( 0x7FFFFFFFFFFFFFFF );
+		}
+		return (sbits64) LIT64( 0x8000000000000000 );
+	}
+	if ( aExp ) aSig |= 0x00800000;
+	aSig64 = aSig;
+	aSig64 <<= 40;
+	shift64ExtraRightJamming( aSig64, 0, shiftCount, &aSig64, &aSigExtra );
+	return roundAndPackInt64( aSign, aSig64, aSigExtra );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the single-precision floating-point value
+| `a' to the 64-bit two's complement integer format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic, except that the conversion is always rounded toward zero.  If
+| `a' is a NaN, the largest positive integer is returned.  Otherwise, if the
+| conversion overflows, the largest integer with the same sign as `a' is
+| returned.
+*----------------------------------------------------------------------------*/
+
+int64 float32_to_int64_round_to_zero( float32 a )
+{
+	flag aSign;
+	int16 aExp, shiftCount;
+	bits32 aSig;
+	bits64 aSig64;
+	int64 z;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	shiftCount = aExp - 0xBE;
+	if ( 0 <= shiftCount ) {
+		if ( a != 0xDF000000 ) {
+			float_raise( float_flag_invalid );
+			if ( ! aSign || ( ( aExp == 0xFF ) && aSig ) ) {
+				return LIT64( 0x7FFFFFFFFFFFFFFF );
+			}
+		}
+		return (sbits64) LIT64( 0x8000000000000000 );
+	}
+	else if ( aExp <= 0x7E ) {
+		if ( aExp | aSig ) float_exception_flags |= float_flag_inexact;
+		return 0;
+	}
+	aSig64 = aSig | 0x00800000;
+	aSig64 <<= 40;
+	z = aSig64>>( - shiftCount );
+	if ( (bits64) ( aSig64<<( shiftCount & 63 ) ) ) {
+		float_exception_flags |= float_flag_inexact;
+	}
+	if ( aSign ) z = - z;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the single-precision floating-point value
+| `a' to the double-precision floating-point format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 float32_to_float64( float32 a )
+{
+	flag aSign;
+	int16 aExp;
+	bits32 aSig;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	if ( aExp == 0xFF ) {
+		if ( aSig ) return commonNaNToFloat64( float32ToCommonNaN( a ) );
+		return packFloat64( aSign, 0x7FF, 0 );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloat64( aSign, 0, 0 );
+		normalizeFloat32Subnormal( aSig, &aExp, &aSig );
+		--aExp;
+	}
+	return packFloat64( aSign, aExp + 0x380, ( (bits64) aSig )<<29 );
+
+}
+
+#ifdef FLOATX80
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the single-precision floating-point value
+| `a' to the extended double-precision floating-point format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 float32_to_floatx80( float32 a )
+{
+	flag aSign;
+	int16 aExp;
+	bits32 aSig;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	if ( aExp == 0xFF ) {
+		if ( aSig ) return commonNaNToFloatx80( float32ToCommonNaN( a ) );
+		return packFloatx80( aSign, 0x7FFF, LIT64( 0x8000000000000000 ) );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloatx80( aSign, 0, 0 );
+		normalizeFloat32Subnormal( aSig, &aExp, &aSig );
+	}
+	aSig |= 0x00800000;
+	return packFloatx80( aSign, aExp + 0x3F80, ( (bits64) aSig )<<40 );
+
+}
+
+#endif
+
+#ifdef FLOAT128
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the single-precision floating-point value
+| `a' to the double-precision floating-point format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 float32_to_float128( float32 a )
+{
+	flag aSign;
+	int16 aExp;
+	bits32 aSig;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	if ( aExp == 0xFF ) {
+		if ( aSig ) return commonNaNToFloat128( float32ToCommonNaN( a ) );
+		return packFloat128( aSign, 0x7FFF, 0, 0 );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloat128( aSign, 0, 0, 0 );
+		normalizeFloat32Subnormal( aSig, &aExp, &aSig );
+		--aExp;
+	}
+	return packFloat128( aSign, aExp + 0x3F80, ( (bits64) aSig )<<25, 0 );
+
+}
+
+#endif
+
+/*----------------------------------------------------------------------------
+| Rounds the single-precision floating-point value `a' to an integer, and
+| returns the result as a single-precision floating-point value.  The
+| operation is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 float32_round_to_int( float32 a )
+{
+	flag aSign;
+	int16 aExp;
+	bits32 lastBitMask, roundBitsMask;
+	int8 roundingMode;
+	float32 z;
+
+	aExp = extractFloat32Exp( a );
+	if ( 0x96 <= aExp ) {
+		if ( ( aExp == 0xFF ) && extractFloat32Frac( a ) ) {
+			return propagateFloat32NaN( a, a );
+		}
+		return a;
+	}
+	if ( aExp <= 0x7E ) {
+		if ( (bits32) ( a<<1 ) == 0 ) return a;
+		float_exception_flags |= float_flag_inexact;
+		aSign = extractFloat32Sign( a );
+		switch ( float_rounding_mode ) {
+			case float_round_nearest_even:
+			if ( ( aExp == 0x7E ) && extractFloat32Frac( a ) ) {
+				return packFloat32( aSign, 0x7F, 0 );
+			}
+			break;
+			case float_round_down:
+			return aSign ? 0xBF800000 : 0;
+			case float_round_up:
+			return aSign ? 0x80000000 : 0x3F800000;
+		}
+		return packFloat32( aSign, 0, 0 );
+	}
+	lastBitMask = 1;
+	lastBitMask <<= 0x96 - aExp;
+	roundBitsMask = lastBitMask - 1;
+	z = a;
+	roundingMode = float_rounding_mode;
+	if ( roundingMode == float_round_nearest_even ) {
+		z += lastBitMask>>1;
+		if ( ( z & roundBitsMask ) == 0 ) z &= ~ lastBitMask;
+	}
+	else if ( roundingMode != float_round_to_zero ) {
+		if ( extractFloat32Sign( z ) ^ ( roundingMode == float_round_up ) ) {
+			z += roundBitsMask;
+		}
+	}
+	z &= ~ roundBitsMask;
+	if ( z != a ) float_exception_flags |= float_flag_inexact;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of adding the absolute values of the single-precision
+| floating-point values `a' and `b'.  If `zSign' is 1, the sum is negated
+| before being returned.  `zSign' is ignored if the result is a NaN.
+| The addition is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static float32 addFloat32Sigs( float32 a, float32 b, flag zSign )
+{
+	int16 aExp, bExp, zExp;
+	bits32 aSig, bSig, zSig;
+	int16 expDiff;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	bSig = extractFloat32Frac( b );
+	bExp = extractFloat32Exp( b );
+	expDiff = aExp - bExp;
+	aSig <<= 6;
+	bSig <<= 6;
+	if ( 0 < expDiff ) {
+		if ( aExp == 0xFF ) {
+			if ( aSig ) return propagateFloat32NaN( a, b );
+			return a;
+		}
+		if ( bExp == 0 ) {
+			--expDiff;
+		}
+		else {
+			bSig |= 0x20000000;
+		}
+		shift32RightJamming( bSig, expDiff, &bSig );
+		zExp = aExp;
+	}
+	else if ( expDiff < 0 ) {
+		if ( bExp == 0xFF ) {
+			if ( bSig ) return propagateFloat32NaN( a, b );
+			return packFloat32( zSign, 0xFF, 0 );
+		}
+		if ( aExp == 0 ) {
+			++expDiff;
+		}
+		else {
+			aSig |= 0x20000000;
+		}
+		shift32RightJamming( aSig, - expDiff, &aSig );
+		zExp = bExp;
+	}
+	else {
+		if ( aExp == 0xFF ) {
+			if ( aSig | bSig ) return propagateFloat32NaN( a, b );
+			return a;
+		}
+		if ( aExp == 0 ) return packFloat32( zSign, 0, ( aSig + bSig )>>6 );
+		zSig = 0x40000000 + aSig + bSig;
+		zExp = aExp;
+		goto roundAndPack;
+	}
+	aSig |= 0x20000000;
+	zSig = ( aSig + bSig )<<1;
+	--zExp;
+	if ( (sbits32) zSig < 0 ) {
+		zSig = aSig + bSig;
+		++zExp;
+	}
+	roundAndPack:
+	return roundAndPackFloat32( zSign, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of subtracting the absolute values of the single-
+| precision floating-point values `a' and `b'.  If `zSign' is 1, the
+| difference is negated before being returned.  `zSign' is ignored if the
+| result is a NaN.  The subtraction is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static float32 subFloat32Sigs( float32 a, float32 b, flag zSign )
+{
+	int16 aExp, bExp, zExp;
+	bits32 aSig, bSig, zSig;
+	int16 expDiff;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	bSig = extractFloat32Frac( b );
+	bExp = extractFloat32Exp( b );
+	expDiff = aExp - bExp;
+	aSig <<= 7;
+	bSig <<= 7;
+	if ( 0 < expDiff ) goto aExpBigger;
+	if ( expDiff < 0 ) goto bExpBigger;
+	if ( aExp == 0xFF ) {
+		if ( aSig | bSig ) return propagateFloat32NaN( a, b );
+		float_raise( float_flag_invalid );
+		return float32_default_nan;
+	}
+	if ( aExp == 0 ) {
+		aExp = 1;
+		bExp = 1;
+	}
+	if ( bSig < aSig ) goto aBigger;
+	if ( aSig < bSig ) goto bBigger;
+	return packFloat32( float_rounding_mode == float_round_down, 0, 0 );
+	bExpBigger:
+	if ( bExp == 0xFF ) {
+		if ( bSig ) return propagateFloat32NaN( a, b );
+		return packFloat32( zSign ^ 1, 0xFF, 0 );
+	}
+	if ( aExp == 0 ) {
+		++expDiff;
+	}
+	else {
+		aSig |= 0x40000000;
+	}
+	shift32RightJamming( aSig, - expDiff, &aSig );
+	bSig |= 0x40000000;
+	bBigger:
+	zSig = bSig - aSig;
+	zExp = bExp;
+	zSign ^= 1;
+	goto normalizeRoundAndPack;
+	aExpBigger:
+	if ( aExp == 0xFF ) {
+		if ( aSig ) return propagateFloat32NaN( a, b );
+		return a;
+	}
+	if ( bExp == 0 ) {
+		--expDiff;
+	}
+	else {
+		bSig |= 0x40000000;
+	}
+	shift32RightJamming( bSig, expDiff, &bSig );
+	aSig |= 0x40000000;
+	aBigger:
+	zSig = aSig - bSig;
+	zExp = aExp;
+	normalizeRoundAndPack:
+	--zExp;
+	return normalizeRoundAndPackFloat32( zSign, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of adding the single-precision floating-point values `a'
+| and `b'.  The operation is performed according to the IEC/IEEE Standard for
+| Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 float32_add( float32 a, float32 b )
+{
+	flag aSign, bSign;
+
+	aSign = extractFloat32Sign( a );
+	bSign = extractFloat32Sign( b );
+	if ( aSign == bSign ) {
+		return addFloat32Sigs( a, b, aSign );
+	}
+	else {
+		return subFloat32Sigs( a, b, aSign );
+	}
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of subtracting the single-precision floating-point values
+| `a' and `b'.  The operation is performed according to the IEC/IEEE Standard
+| for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 float32_sub( float32 a, float32 b )
+{
+	flag aSign, bSign;
+
+	aSign = extractFloat32Sign( a );
+	bSign = extractFloat32Sign( b );
+	if ( aSign == bSign ) {
+		return subFloat32Sigs( a, b, aSign );
+	}
+	else {
+		return addFloat32Sigs( a, b, aSign );
+	}
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of multiplying the single-precision floating-point values
+| `a' and `b'.  The operation is performed according to the IEC/IEEE Standard
+| for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 float32_mul( float32 a, float32 b )
+{
+	flag aSign, bSign, zSign;
+	int16 aExp, bExp, zExp;
+	bits32 aSig, bSig;
+	bits64 zSig64;
+	bits32 zSig;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	bSig = extractFloat32Frac( b );
+	bExp = extractFloat32Exp( b );
+	bSign = extractFloat32Sign( b );
+	zSign = aSign ^ bSign;
+	if ( aExp == 0xFF ) {
+		if ( aSig || ( ( bExp == 0xFF ) && bSig ) ) {
+			return propagateFloat32NaN( a, b );
+		}
+		if ( ( bExp | bSig ) == 0 ) {
+			float_raise( float_flag_invalid );
+			return float32_default_nan;
+		}
+		return packFloat32( zSign, 0xFF, 0 );
+	}
+	if ( bExp == 0xFF ) {
+		if ( bSig ) return propagateFloat32NaN( a, b );
+		if ( ( aExp | aSig ) == 0 ) {
+			float_raise( float_flag_invalid );
+			return float32_default_nan;
+		}
+		return packFloat32( zSign, 0xFF, 0 );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloat32( zSign, 0, 0 );
+		normalizeFloat32Subnormal( aSig, &aExp, &aSig );
+	}
+	if ( bExp == 0 ) {
+		if ( bSig == 0 ) return packFloat32( zSign, 0, 0 );
+		normalizeFloat32Subnormal( bSig, &bExp, &bSig );
+	}
+	zExp = aExp + bExp - 0x7F;
+	aSig = ( aSig | 0x00800000 )<<7;
+	bSig = ( bSig | 0x00800000 )<<8;
+	shift64RightJamming( ( (bits64) aSig ) * bSig, 32, &zSig64 );
+	zSig = zSig64;
+	if ( 0 <= (sbits32) ( zSig<<1 ) ) {
+		zSig <<= 1;
+		--zExp;
+	}
+	return roundAndPackFloat32( zSign, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of dividing the single-precision floating-point value `a'
+| by the corresponding value `b'.  The operation is performed according to the
+| IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 float32_div( float32 a, float32 b )
+{
+	flag aSign, bSign, zSign;
+	int16 aExp, bExp, zExp;
+	bits32 aSig, bSig, zSig;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	bSig = extractFloat32Frac( b );
+	bExp = extractFloat32Exp( b );
+	bSign = extractFloat32Sign( b );
+	zSign = aSign ^ bSign;
+	if ( aExp == 0xFF ) {
+		if ( aSig ) return propagateFloat32NaN( a, b );
+		if ( bExp == 0xFF ) {
+			if ( bSig ) return propagateFloat32NaN( a, b );
+			float_raise( float_flag_invalid );
+			return float32_default_nan;
+		}
+		return packFloat32( zSign, 0xFF, 0 );
+	}
+	if ( bExp == 0xFF ) {
+		if ( bSig ) return propagateFloat32NaN( a, b );
+		return packFloat32( zSign, 0, 0 );
+	}
+	if ( bExp == 0 ) {
+		if ( bSig == 0 ) {
+			if ( ( aExp | aSig ) == 0 ) {
+				float_raise( float_flag_invalid );
+				return float32_default_nan;
+			}
+			float_raise( float_flag_divbyzero );
+			return packFloat32( zSign, 0xFF, 0 );
+		}
+		normalizeFloat32Subnormal( bSig, &bExp, &bSig );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloat32( zSign, 0, 0 );
+		normalizeFloat32Subnormal( aSig, &aExp, &aSig );
+	}
+	zExp = aExp - bExp + 0x7D;
+	aSig = ( aSig | 0x00800000 )<<7;
+	bSig = ( bSig | 0x00800000 )<<8;
+	if ( bSig <= ( aSig + aSig ) ) {
+		aSig >>= 1;
+		++zExp;
+	}
+	zSig = ( ( (bits64) aSig )<<32 ) / bSig;
+	if ( ( zSig & 0x3F ) == 0 ) {
+		zSig |= ( (bits64) bSig * zSig != ( (bits64) aSig )<<32 );
+	}
+	return roundAndPackFloat32( zSign, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the remainder of the single-precision floating-point value `a'
+| with respect to the corresponding value `b'.  The operation is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 float32_rem( float32 a, float32 b )
+{
+	flag aSign, zSign;
+	int16 aExp, bExp, expDiff;
+	bits32 aSig, bSig;
+	bits32 q;
+	bits64 aSig64, bSig64, q64;
+	bits32 alternateASig;
+	sbits32 sigMean;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	bSig = extractFloat32Frac( b );
+	bExp = extractFloat32Exp( b );
+//    bSign = extractFloat32Sign( b );
+	if ( aExp == 0xFF ) {
+		if ( aSig || ( ( bExp == 0xFF ) && bSig ) ) {
+			return propagateFloat32NaN( a, b );
+		}
+		float_raise( float_flag_invalid );
+		return float32_default_nan;
+	}
+	if ( bExp == 0xFF ) {
+		if ( bSig ) return propagateFloat32NaN( a, b );
+		return a;
+	}
+	if ( bExp == 0 ) {
+		if ( bSig == 0 ) {
+			float_raise( float_flag_invalid );
+			return float32_default_nan;
+		}
+		normalizeFloat32Subnormal( bSig, &bExp, &bSig );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return a;
+		normalizeFloat32Subnormal( aSig, &aExp, &aSig );
+	}
+	expDiff = aExp - bExp;
+	aSig |= 0x00800000;
+	bSig |= 0x00800000;
+	if ( expDiff < 32 ) {
+		aSig <<= 8;
+		bSig <<= 8;
+		if ( expDiff < 0 ) {
+			if ( expDiff < -1 ) return a;
+			aSig >>= 1;
+		}
+		q = ( bSig <= aSig );
+		if ( q ) aSig -= bSig;
+		if ( 0 < expDiff ) {
+			q = ( ( (bits64) aSig )<<32 ) / bSig;
+			q >>= 32 - expDiff;
+			bSig >>= 2;
+			aSig = ( ( aSig>>1 )<<( expDiff - 1 ) ) - bSig * q;
+		}
+		else {
+			aSig >>= 2;
+			bSig >>= 2;
+		}
+	}
+	else {
+		if ( bSig <= aSig ) aSig -= bSig;
+		aSig64 = ( (bits64) aSig )<<40;
+		bSig64 = ( (bits64) bSig )<<40;
+		expDiff -= 64;
+		while ( 0 < expDiff ) {
+			q64 = estimateDiv128To64( aSig64, 0, bSig64 );
+			q64 = ( 2 < q64 ) ? q64 - 2 : 0;
+			aSig64 = - ( ( bSig * q64 )<<38 );
+			expDiff -= 62;
+		}
+		expDiff += 64;
+		q64 = estimateDiv128To64( aSig64, 0, bSig64 );
+		q64 = ( 2 < q64 ) ? q64 - 2 : 0;
+		q = q64>>( 64 - expDiff );
+		bSig <<= 6;
+		aSig = ( ( aSig64>>33 )<<( expDiff - 1 ) ) - bSig * q;
+	}
+	do {
+		alternateASig = aSig;
+		++q;
+		aSig -= bSig;
+	} while ( 0 <= (sbits32) aSig );
+	sigMean = aSig + alternateASig;
+	if ( ( sigMean < 0 ) || ( ( sigMean == 0 ) && ( q & 1 ) ) ) {
+		aSig = alternateASig;
+	}
+	zSign = ( (sbits32) aSig < 0 );
+	if ( zSign ) aSig = - aSig;
+	return normalizeRoundAndPackFloat32( aSign ^ zSign, bExp, aSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the square root of the single-precision floating-point value `a'.
+| The operation is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 float32_sqrt( float32 a )
+{
+	flag aSign;
+	int16 aExp, zExp;
+	bits32 aSig, zSig;
+	bits64 rem, term;
+
+	aSig = extractFloat32Frac( a );
+	aExp = extractFloat32Exp( a );
+	aSign = extractFloat32Sign( a );
+	if ( aExp == 0xFF ) {
+		if ( aSig ) return propagateFloat32NaN( a, 0 );
+		if ( ! aSign ) return a;
+		float_raise( float_flag_invalid );
+		return float32_default_nan;
+	}
+	if ( aSign ) {
+		if ( ( aExp | aSig ) == 0 ) return a;
+		float_raise( float_flag_invalid );
+		return float32_default_nan;
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return 0;
+		normalizeFloat32Subnormal( aSig, &aExp, &aSig );
+	}
+	zExp = ( ( aExp - 0x7F )>>1 ) + 0x7E;
+	aSig = ( aSig | 0x00800000 )<<8;
+	zSig = estimateSqrt32( aExp, aSig ) + 2;
+	if ( ( zSig & 0x7F ) <= 5 ) {
+		if ( zSig < 2 ) {
+			zSig = 0x7FFFFFFF;
+			goto roundAndPack;
+		}
+		aSig >>= aExp & 1;
+		term = ( (bits64) zSig ) * zSig;
+		rem = ( ( (bits64) aSig )<<32 ) - term;
+		while ( (sbits64) rem < 0 ) {
+			--zSig;
+			rem += ( ( (bits64) zSig )<<1 ) | 1;
+		}
+		zSig |= ( rem != 0 );
+	}
+	shift32RightJamming( zSig, 1, &zSig );
+	roundAndPack:
+	return roundAndPackFloat32( 0, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the single-precision floating-point value `a' is equal to
+| the corresponding value `b', and 0 otherwise.  The comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float32_eq( float32 a, float32 b )
+{
+	if (    ( ( extractFloat32Exp( a ) == 0xFF ) && extractFloat32Frac( a ) )
+			|| ( ( extractFloat32Exp( b ) == 0xFF ) && extractFloat32Frac( b ) )
+		) {
+		if ( float32_is_signaling_nan( a ) || float32_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	return ( a == b ) || ( (bits32) ( ( a | b )<<1 ) == 0 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the single-precision floating-point value `a' is less than
+| or equal to the corresponding value `b', and 0 otherwise.  The comparison
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float32_le( float32 a, float32 b )
+{
+	flag aSign, bSign;
+
+	if (    ( ( extractFloat32Exp( a ) == 0xFF ) && extractFloat32Frac( a ) )
+			|| ( ( extractFloat32Exp( b ) == 0xFF ) && extractFloat32Frac( b ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	aSign = extractFloat32Sign( a );
+	bSign = extractFloat32Sign( b );
+	if ( aSign != bSign ) return aSign || ( (bits32) ( ( a | b )<<1 ) == 0 );
+	return ( a == b ) || ( aSign ^ ( a < b ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the single-precision floating-point value `a' is less than
+| the corresponding value `b', and 0 otherwise.  The comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float32_lt( float32 a, float32 b )
+{
+	flag aSign, bSign;
+
+	if (    ( ( extractFloat32Exp( a ) == 0xFF ) && extractFloat32Frac( a ) )
+			|| ( ( extractFloat32Exp( b ) == 0xFF ) && extractFloat32Frac( b ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	aSign = extractFloat32Sign( a );
+	bSign = extractFloat32Sign( b );
+	if ( aSign != bSign ) return aSign && ( (bits32) ( ( a | b )<<1 ) != 0 );
+	return ( a != b ) && ( aSign ^ ( a < b ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the single-precision floating-point value `a' is equal to
+| the corresponding value `b', and 0 otherwise.  The invalid exception is
+| raised if either operand is a NaN.  Otherwise, the comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float32_eq_signaling( float32 a, float32 b )
+{
+	if (    ( ( extractFloat32Exp( a ) == 0xFF ) && extractFloat32Frac( a ) )
+			|| ( ( extractFloat32Exp( b ) == 0xFF ) && extractFloat32Frac( b ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	return ( a == b ) || ( (bits32) ( ( a | b )<<1 ) == 0 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the single-precision floating-point value `a' is less than or
+| equal to the corresponding value `b', and 0 otherwise.  Quiet NaNs do not
+| cause an exception.  Otherwise, the comparison is performed according to the
+| IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float32_le_quiet( float32 a, float32 b )
+{
+	flag aSign, bSign;
+//    int16 aExp, bExp;
+
+	if (    ( ( extractFloat32Exp( a ) == 0xFF ) && extractFloat32Frac( a ) )
+			|| ( ( extractFloat32Exp( b ) == 0xFF ) && extractFloat32Frac( b ) )
+		) {
+		if ( float32_is_signaling_nan( a ) || float32_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	aSign = extractFloat32Sign( a );
+	bSign = extractFloat32Sign( b );
+	if ( aSign != bSign ) return aSign || ( (bits32) ( ( a | b )<<1 ) == 0 );
+	return ( a == b ) || ( aSign ^ ( a < b ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the single-precision floating-point value `a' is less than
+| the corresponding value `b', and 0 otherwise.  Quiet NaNs do not cause an
+| exception.  Otherwise, the comparison is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float32_lt_quiet( float32 a, float32 b )
+{
+	flag aSign, bSign;
+
+	if (    ( ( extractFloat32Exp( a ) == 0xFF ) && extractFloat32Frac( a ) )
+			|| ( ( extractFloat32Exp( b ) == 0xFF ) && extractFloat32Frac( b ) )
+		) {
+		if ( float32_is_signaling_nan( a ) || float32_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	aSign = extractFloat32Sign( a );
+	bSign = extractFloat32Sign( b );
+	if ( aSign != bSign ) return aSign && ( (bits32) ( ( a | b )<<1 ) != 0 );
+	return ( a != b ) && ( aSign ^ ( a < b ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the double-precision floating-point value
+| `a' to the 32-bit two's complement integer format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic---which means in particular that the conversion is rounded
+| according to the current rounding mode.  If `a' is a NaN, the largest
+| positive integer is returned.  Otherwise, if the conversion overflows, the
+| largest integer with the same sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int32 float64_to_int32( float64 a )
+{
+	flag aSign;
+	int16 aExp, shiftCount;
+	bits64 aSig;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	if ( ( aExp == 0x7FF ) && aSig ) aSign = 0;
+	if ( aExp ) aSig |= LIT64( 0x0010000000000000 );
+	shiftCount = 0x42C - aExp;
+	if ( 0 < shiftCount ) shift64RightJamming( aSig, shiftCount, &aSig );
+	return roundAndPackInt32( aSign, aSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the double-precision floating-point value
+| `a' to the 32-bit two's complement integer format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic, except that the conversion is always rounded toward zero.
+| If `a' is a NaN, the largest positive integer is returned.  Otherwise, if
+| the conversion overflows, the largest integer with the same sign as `a' is
+| returned.
+*----------------------------------------------------------------------------*/
+
+int32 float64_to_int32_round_to_zero( float64 a )
+{
+	flag aSign;
+	int16 aExp, shiftCount;
+	bits64 aSig, savedASig;
+	int32 z;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	if ( 0x41E < aExp ) {
+		if ( ( aExp == 0x7FF ) && aSig ) aSign = 0;
+		goto invalid;
+	}
+	else if ( aExp < 0x3FF ) {
+		if ( aExp || aSig ) float_exception_flags |= float_flag_inexact;
+		return 0;
+	}
+	aSig |= LIT64( 0x0010000000000000 );
+	shiftCount = 0x433 - aExp;
+	savedASig = aSig;
+	aSig >>= shiftCount;
+	z = aSig;
+	if ( aSign ) z = - z;
+	if ( ( z < 0 ) ^ aSign ) {
+	invalid:
+		float_raise( float_flag_invalid );
+		return aSign ? (sbits32) 0x80000000 : 0x7FFFFFFF;
+	}
+	if ( ( aSig<<shiftCount ) != savedASig ) {
+		float_exception_flags |= float_flag_inexact;
+	}
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the double-precision floating-point value
+| `a' to the 64-bit two's complement integer format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic---which means in particular that the conversion is rounded
+| according to the current rounding mode.  If `a' is a NaN, the largest
+| positive integer is returned.  Otherwise, if the conversion overflows, the
+| largest integer with the same sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int64 float64_to_int64( float64 a )
+{
+	flag aSign;
+	int16 aExp, shiftCount;
+	bits64 aSig, aSigExtra;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	if ( aExp ) aSig |= LIT64( 0x0010000000000000 );
+	shiftCount = 0x433 - aExp;
+	if ( shiftCount <= 0 ) {
+		if ( 0x43E < aExp ) {
+			float_raise( float_flag_invalid );
+			if (    ! aSign
+					|| (    ( aExp == 0x7FF )
+						&& ( aSig != LIT64( 0x0010000000000000 ) ) )
+				) {
+				return LIT64( 0x7FFFFFFFFFFFFFFF );
+			}
+			return (sbits64) LIT64( 0x8000000000000000 );
+		}
+		aSigExtra = 0;
+		aSig <<= - shiftCount;
+	}
+	else {
+		shift64ExtraRightJamming( aSig, 0, shiftCount, &aSig, &aSigExtra );
+	}
+	return roundAndPackInt64( aSign, aSig, aSigExtra );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the double-precision floating-point value
+| `a' to the 64-bit two's complement integer format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic, except that the conversion is always rounded toward zero.
+| If `a' is a NaN, the largest positive integer is returned.  Otherwise, if
+| the conversion overflows, the largest integer with the same sign as `a' is
+| returned.
+*----------------------------------------------------------------------------*/
+
+int64 float64_to_int64_round_to_zero( float64 a )
+{
+	flag aSign;
+	int16 aExp, shiftCount;
+	bits64 aSig;
+	int64 z;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	if ( aExp ) aSig |= LIT64( 0x0010000000000000 );
+	shiftCount = aExp - 0x433;
+	if ( 0 <= shiftCount ) {
+		if ( 0x43E <= aExp ) {
+			if ( a != LIT64( 0xC3E0000000000000 ) ) {
+				float_raise( float_flag_invalid );
+				if (    ! aSign
+						|| (    ( aExp == 0x7FF )
+							&& ( aSig != LIT64( 0x0010000000000000 ) ) )
+					) {
+					return LIT64( 0x7FFFFFFFFFFFFFFF );
+				}
+			}
+			return (sbits64) LIT64( 0x8000000000000000 );
+		}
+		z = aSig<<shiftCount;
+	}
+	else {
+		if ( aExp < 0x3FE ) {
+			if ( aExp | aSig ) float_exception_flags |= float_flag_inexact;
+			return 0;
+		}
+		z = aSig>>( - shiftCount );
+		if ( (bits64) ( aSig<<( shiftCount & 63 ) ) ) {
+			float_exception_flags |= float_flag_inexact;
+		}
+	}
+	if ( aSign ) z = - z;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the double-precision floating-point value
+| `a' to the single-precision floating-point format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 float64_to_float32( float64 a )
+{
+	flag aSign;
+	int16 aExp;
+	bits64 aSig;
+	bits32 zSig;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	if ( aExp == 0x7FF ) {
+		if ( aSig ) return commonNaNToFloat32( float64ToCommonNaN( a ) );
+		return packFloat32( aSign, 0xFF, 0 );
+	}
+	shift64RightJamming( aSig, 22, &aSig );
+	zSig = aSig;
+	if ( aExp || zSig ) {
+		zSig |= 0x40000000;
+		aExp -= 0x381;
+	}
+	return roundAndPackFloat32( aSign, aExp, zSig );
+
+}
+
+#ifdef FLOATX80
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the double-precision floating-point value
+| `a' to the extended double-precision floating-point format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 float64_to_floatx80( float64 a )
+{
+	flag aSign;
+	int16 aExp;
+	bits64 aSig;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	if ( aExp == 0x7FF ) {
+		if ( aSig ) return commonNaNToFloatx80( float64ToCommonNaN( a ) );
+		return packFloatx80( aSign, 0x7FFF, LIT64( 0x8000000000000000 ) );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloatx80( aSign, 0, 0 );
+		normalizeFloat64Subnormal( aSig, &aExp, &aSig );
+	}
+	return
+		packFloatx80(
+			aSign, aExp + 0x3C00, ( aSig | LIT64( 0x0010000000000000 ) )<<11 );
+
+}
+
+#endif
+
+#ifdef FLOAT128
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the double-precision floating-point value
+| `a' to the quadruple-precision floating-point format.  The conversion is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 float64_to_float128( float64 a )
+{
+	flag aSign;
+	int16 aExp;
+	bits64 aSig, zSig0, zSig1;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	if ( aExp == 0x7FF ) {
+		if ( aSig ) return commonNaNToFloat128( float64ToCommonNaN( a ) );
+		return packFloat128( aSign, 0x7FFF, 0, 0 );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloat128( aSign, 0, 0, 0 );
+		normalizeFloat64Subnormal( aSig, &aExp, &aSig );
+		--aExp;
+	}
+	shift128Right( aSig, 0, 4, &zSig0, &zSig1 );
+	return packFloat128( aSign, aExp + 0x3C00, zSig0, zSig1 );
+
+}
+
+#endif
+
+/*----------------------------------------------------------------------------
+| Rounds the double-precision floating-point value `a' to an integer, and
+| returns the result as a double-precision floating-point value.  The
+| operation is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 float64_round_to_int( float64 a )
+{
+	flag aSign;
+	int16 aExp;
+	bits64 lastBitMask, roundBitsMask;
+	int8 roundingMode;
+	float64 z;
+
+	aExp = extractFloat64Exp( a );
+	if ( 0x433 <= aExp ) {
+		if ( ( aExp == 0x7FF ) && extractFloat64Frac( a ) ) {
+			return propagateFloat64NaN( a, a );
+		}
+		return a;
+	}
+	if ( aExp < 0x3FF ) {
+		if ( (bits64) ( a<<1 ) == 0 ) return a;
+		float_exception_flags |= float_flag_inexact;
+		aSign = extractFloat64Sign( a );
+		switch ( float_rounding_mode ) {
+			case float_round_nearest_even:
+			if ( ( aExp == 0x3FE ) && extractFloat64Frac( a ) ) {
+				return packFloat64( aSign, 0x3FF, 0 );
+			}
+			break;
+			case float_round_down:
+			return aSign ? LIT64( 0xBFF0000000000000 ) : 0;
+			case float_round_up:
+			return
+			aSign ? LIT64( 0x8000000000000000 ) : LIT64( 0x3FF0000000000000 );
+		}
+		return packFloat64( aSign, 0, 0 );
+	}
+	lastBitMask = 1;
+	lastBitMask <<= 0x433 - aExp;
+	roundBitsMask = lastBitMask - 1;
+	z = a;
+	roundingMode = float_rounding_mode;
+	if ( roundingMode == float_round_nearest_even ) {
+		z += lastBitMask>>1;
+		if ( ( z & roundBitsMask ) == 0 ) z &= ~ lastBitMask;
+	}
+	else if ( roundingMode != float_round_to_zero ) {
+		if ( extractFloat64Sign( z ) ^ ( roundingMode == float_round_up ) ) {
+			z += roundBitsMask;
+		}
+	}
+	z &= ~ roundBitsMask;
+	if ( z != a ) float_exception_flags |= float_flag_inexact;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of adding the absolute values of the double-precision
+| floating-point values `a' and `b'.  If `zSign' is 1, the sum is negated
+| before being returned.  `zSign' is ignored if the result is a NaN.
+| The addition is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static float64 addFloat64Sigs( float64 a, float64 b, flag zSign )
+{
+	int16 aExp, bExp, zExp;
+	bits64 aSig, bSig, zSig;
+	int16 expDiff;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	bSig = extractFloat64Frac( b );
+	bExp = extractFloat64Exp( b );
+	expDiff = aExp - bExp;
+	aSig <<= 9;
+	bSig <<= 9;
+	if ( 0 < expDiff ) {
+		if ( aExp == 0x7FF ) {
+			if ( aSig ) return propagateFloat64NaN( a, b );
+			return a;
+		}
+		if ( bExp == 0 ) {
+			--expDiff;
+		}
+		else {
+			bSig |= LIT64( 0x2000000000000000 );
+		}
+		shift64RightJamming( bSig, expDiff, &bSig );
+		zExp = aExp;
+	}
+	else if ( expDiff < 0 ) {
+		if ( bExp == 0x7FF ) {
+			if ( bSig ) return propagateFloat64NaN( a, b );
+			return packFloat64( zSign, 0x7FF, 0 );
+		}
+		if ( aExp == 0 ) {
+			++expDiff;
+		}
+		else {
+			aSig |= LIT64( 0x2000000000000000 );
+		}
+		shift64RightJamming( aSig, - expDiff, &aSig );
+		zExp = bExp;
+	}
+	else {
+		if ( aExp == 0x7FF ) {
+			if ( aSig | bSig ) return propagateFloat64NaN( a, b );
+			return a;
+		}
+		if ( aExp == 0 ) return packFloat64( zSign, 0, ( aSig + bSig )>>9 );
+		zSig = LIT64( 0x4000000000000000 ) + aSig + bSig;
+		zExp = aExp;
+		goto roundAndPack;
+	}
+	aSig |= LIT64( 0x2000000000000000 );
+	zSig = ( aSig + bSig )<<1;
+	--zExp;
+	if ( (sbits64) zSig < 0 ) {
+		zSig = aSig + bSig;
+		++zExp;
+	}
+	roundAndPack:
+	return roundAndPackFloat64( zSign, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of subtracting the absolute values of the double-
+| precision floating-point values `a' and `b'.  If `zSign' is 1, the
+| difference is negated before being returned.  `zSign' is ignored if the
+| result is a NaN.  The subtraction is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static float64 subFloat64Sigs( float64 a, float64 b, flag zSign )
+{
+	int16 aExp, bExp, zExp;
+	bits64 aSig, bSig, zSig;
+	int16 expDiff;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	bSig = extractFloat64Frac( b );
+	bExp = extractFloat64Exp( b );
+	expDiff = aExp - bExp;
+	aSig <<= 10;
+	bSig <<= 10;
+	if ( 0 < expDiff ) goto aExpBigger;
+	if ( expDiff < 0 ) goto bExpBigger;
+	if ( aExp == 0x7FF ) {
+		if ( aSig | bSig ) return propagateFloat64NaN( a, b );
+		float_raise( float_flag_invalid );
+		return float64_default_nan;
+	}
+	if ( aExp == 0 ) {
+		aExp = 1;
+		bExp = 1;
+	}
+	if ( bSig < aSig ) goto aBigger;
+	if ( aSig < bSig ) goto bBigger;
+	return packFloat64( float_rounding_mode == float_round_down, 0, 0 );
+	bExpBigger:
+	if ( bExp == 0x7FF ) {
+		if ( bSig ) return propagateFloat64NaN( a, b );
+		return packFloat64( zSign ^ 1, 0x7FF, 0 );
+	}
+	if ( aExp == 0 ) {
+		++expDiff;
+	}
+	else {
+		aSig |= LIT64( 0x4000000000000000 );
+	}
+	shift64RightJamming( aSig, - expDiff, &aSig );
+	bSig |= LIT64( 0x4000000000000000 );
+	bBigger:
+	zSig = bSig - aSig;
+	zExp = bExp;
+	zSign ^= 1;
+	goto normalizeRoundAndPack;
+	aExpBigger:
+	if ( aExp == 0x7FF ) {
+		if ( aSig ) return propagateFloat64NaN( a, b );
+		return a;
+	}
+	if ( bExp == 0 ) {
+		--expDiff;
+	}
+	else {
+		bSig |= LIT64( 0x4000000000000000 );
+	}
+	shift64RightJamming( bSig, expDiff, &bSig );
+	aSig |= LIT64( 0x4000000000000000 );
+	aBigger:
+	zSig = aSig - bSig;
+	zExp = aExp;
+	normalizeRoundAndPack:
+	--zExp;
+	return normalizeRoundAndPackFloat64( zSign, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of adding the double-precision floating-point values `a'
+| and `b'.  The operation is performed according to the IEC/IEEE Standard for
+| Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 float64_add( float64 a, float64 b )
+{
+	flag aSign, bSign;
+
+	aSign = extractFloat64Sign( a );
+	bSign = extractFloat64Sign( b );
+	if ( aSign == bSign ) {
+		return addFloat64Sigs( a, b, aSign );
+	}
+	else {
+		return subFloat64Sigs( a, b, aSign );
+	}
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of subtracting the double-precision floating-point values
+| `a' and `b'.  The operation is performed according to the IEC/IEEE Standard
+| for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 float64_sub( float64 a, float64 b )
+{
+	flag aSign, bSign;
+
+	aSign = extractFloat64Sign( a );
+	bSign = extractFloat64Sign( b );
+	if ( aSign == bSign ) {
+		return subFloat64Sigs( a, b, aSign );
+	}
+	else {
+		return addFloat64Sigs( a, b, aSign );
+	}
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of multiplying the double-precision floating-point values
+| `a' and `b'.  The operation is performed according to the IEC/IEEE Standard
+| for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 float64_mul( float64 a, float64 b )
+{
+	flag aSign, bSign, zSign;
+	int16 aExp, bExp, zExp;
+	bits64 aSig, bSig, zSig0, zSig1;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	bSig = extractFloat64Frac( b );
+	bExp = extractFloat64Exp( b );
+	bSign = extractFloat64Sign( b );
+	zSign = aSign ^ bSign;
+	if ( aExp == 0x7FF ) {
+		if ( aSig || ( ( bExp == 0x7FF ) && bSig ) ) {
+			return propagateFloat64NaN( a, b );
+		}
+		if ( ( bExp | bSig ) == 0 ) {
+			float_raise( float_flag_invalid );
+			return float64_default_nan;
+		}
+		return packFloat64( zSign, 0x7FF, 0 );
+	}
+	if ( bExp == 0x7FF ) {
+		if ( bSig ) return propagateFloat64NaN( a, b );
+		if ( ( aExp | aSig ) == 0 ) {
+			float_raise( float_flag_invalid );
+			return float64_default_nan;
+		}
+		return packFloat64( zSign, 0x7FF, 0 );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloat64( zSign, 0, 0 );
+		normalizeFloat64Subnormal( aSig, &aExp, &aSig );
+	}
+	if ( bExp == 0 ) {
+		if ( bSig == 0 ) return packFloat64( zSign, 0, 0 );
+		normalizeFloat64Subnormal( bSig, &bExp, &bSig );
+	}
+	zExp = aExp + bExp - 0x3FF;
+	aSig = ( aSig | LIT64( 0x0010000000000000 ) )<<10;
+	bSig = ( bSig | LIT64( 0x0010000000000000 ) )<<11;
+	mul64To128( aSig, bSig, &zSig0, &zSig1 );
+	zSig0 |= ( zSig1 != 0 );
+	if ( 0 <= (sbits64) ( zSig0<<1 ) ) {
+		zSig0 <<= 1;
+		--zExp;
+	}
+	return roundAndPackFloat64( zSign, zExp, zSig0 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of dividing the double-precision floating-point value `a'
+| by the corresponding value `b'.  The operation is performed according to
+| the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 float64_div( float64 a, float64 b )
+{
+	flag aSign, bSign, zSign;
+	int16 aExp, bExp, zExp;
+	bits64 aSig, bSig, zSig;
+	bits64 rem0, rem1;
+	bits64 term0, term1;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	bSig = extractFloat64Frac( b );
+	bExp = extractFloat64Exp( b );
+	bSign = extractFloat64Sign( b );
+	zSign = aSign ^ bSign;
+	if ( aExp == 0x7FF ) {
+		if ( aSig ) return propagateFloat64NaN( a, b );
+		if ( bExp == 0x7FF ) {
+			if ( bSig ) return propagateFloat64NaN( a, b );
+			float_raise( float_flag_invalid );
+			return float64_default_nan;
+		}
+		return packFloat64( zSign, 0x7FF, 0 );
+	}
+	if ( bExp == 0x7FF ) {
+		if ( bSig ) return propagateFloat64NaN( a, b );
+		return packFloat64( zSign, 0, 0 );
+	}
+	if ( bExp == 0 ) {
+		if ( bSig == 0 ) {
+			if ( ( aExp | aSig ) == 0 ) {
+				float_raise( float_flag_invalid );
+				return float64_default_nan;
+			}
+			float_raise( float_flag_divbyzero );
+			return packFloat64( zSign, 0x7FF, 0 );
+		}
+		normalizeFloat64Subnormal( bSig, &bExp, &bSig );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloat64( zSign, 0, 0 );
+		normalizeFloat64Subnormal( aSig, &aExp, &aSig );
+	}
+	zExp = aExp - bExp + 0x3FD;
+	aSig = ( aSig | LIT64( 0x0010000000000000 ) )<<10;
+	bSig = ( bSig | LIT64( 0x0010000000000000 ) )<<11;
+	if ( bSig <= ( aSig + aSig ) ) {
+		aSig >>= 1;
+		++zExp;
+	}
+	zSig = estimateDiv128To64( aSig, 0, bSig );
+	if ( ( zSig & 0x1FF ) <= 2 ) {
+		mul64To128( bSig, zSig, &term0, &term1 );
+		sub128( aSig, 0, term0, term1, &rem0, &rem1 );
+		while ( (sbits64) rem0 < 0 ) {
+			--zSig;
+			add128( rem0, rem1, 0, bSig, &rem0, &rem1 );
+		}
+		zSig |= ( rem1 != 0 );
+	}
+	return roundAndPackFloat64( zSign, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the remainder of the double-precision floating-point value `a'
+| with respect to the corresponding value `b'.  The operation is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 float64_rem( float64 a, float64 b )
+{
+	flag aSign, zSign;
+	int16 aExp, bExp, expDiff;
+	bits64 aSig, bSig;
+	bits64 q, alternateASig;
+	sbits64 sigMean;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	bSig = extractFloat64Frac( b );
+	bExp = extractFloat64Exp( b );
+//    bSign = extractFloat64Sign( b );
+	if ( aExp == 0x7FF ) {
+		if ( aSig || ( ( bExp == 0x7FF ) && bSig ) ) {
+			return propagateFloat64NaN( a, b );
+		}
+		float_raise( float_flag_invalid );
+		return float64_default_nan;
+	}
+	if ( bExp == 0x7FF ) {
+		if ( bSig ) return propagateFloat64NaN( a, b );
+		return a;
+	}
+	if ( bExp == 0 ) {
+		if ( bSig == 0 ) {
+			float_raise( float_flag_invalid );
+			return float64_default_nan;
+		}
+		normalizeFloat64Subnormal( bSig, &bExp, &bSig );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return a;
+		normalizeFloat64Subnormal( aSig, &aExp, &aSig );
+	}
+	expDiff = aExp - bExp;
+	aSig = ( aSig | LIT64( 0x0010000000000000 ) )<<11;
+	bSig = ( bSig | LIT64( 0x0010000000000000 ) )<<11;
+	if ( expDiff < 0 ) {
+		if ( expDiff < -1 ) return a;
+		aSig >>= 1;
+	}
+	q = ( bSig <= aSig );
+	if ( q ) aSig -= bSig;
+	expDiff -= 64;
+	while ( 0 < expDiff ) {
+		q = estimateDiv128To64( aSig, 0, bSig );
+		q = ( 2 < q ) ? q - 2 : 0;
+		aSig = - ( ( bSig>>2 ) * q );
+		expDiff -= 62;
+	}
+	expDiff += 64;
+	if ( 0 < expDiff ) {
+		q = estimateDiv128To64( aSig, 0, bSig );
+		q = ( 2 < q ) ? q - 2 : 0;
+		q >>= 64 - expDiff;
+		bSig >>= 2;
+		aSig = ( ( aSig>>1 )<<( expDiff - 1 ) ) - bSig * q;
+	}
+	else {
+		aSig >>= 2;
+		bSig >>= 2;
+	}
+	do {
+		alternateASig = aSig;
+		++q;
+		aSig -= bSig;
+	} while ( 0 <= (sbits64) aSig );
+	sigMean = aSig + alternateASig;
+	if ( ( sigMean < 0 ) || ( ( sigMean == 0 ) && ( q & 1 ) ) ) {
+		aSig = alternateASig;
+	}
+	zSign = ( (sbits64) aSig < 0 );
+	if ( zSign ) aSig = - aSig;
+	return normalizeRoundAndPackFloat64( aSign ^ zSign, bExp, aSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the square root of the double-precision floating-point value `a'.
+| The operation is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 float64_sqrt( float64 a )
+{
+	flag aSign;
+	int16 aExp, zExp;
+	bits64 aSig, zSig, doubleZSig;
+	bits64 rem0, rem1, term0, term1;
+//    float64 z;
+
+	aSig = extractFloat64Frac( a );
+	aExp = extractFloat64Exp( a );
+	aSign = extractFloat64Sign( a );
+	if ( aExp == 0x7FF ) {
+		if ( aSig ) return propagateFloat64NaN( a, a );
+		if ( ! aSign ) return a;
+		float_raise( float_flag_invalid );
+		return float64_default_nan;
+	}
+	if ( aSign ) {
+		if ( ( aExp | aSig ) == 0 ) return a;
+		float_raise( float_flag_invalid );
+		return float64_default_nan;
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return 0;
+		normalizeFloat64Subnormal( aSig, &aExp, &aSig );
+	}
+	zExp = ( ( aExp - 0x3FF )>>1 ) + 0x3FE;
+	aSig |= LIT64( 0x0010000000000000 );
+	zSig = estimateSqrt32( aExp, aSig>>21 );
+	aSig <<= 9 - ( aExp & 1 );
+	zSig = estimateDiv128To64( aSig, 0, zSig<<32 ) + ( zSig<<30 );
+	if ( ( zSig & 0x1FF ) <= 5 ) {
+		doubleZSig = zSig<<1;
+		mul64To128( zSig, zSig, &term0, &term1 );
+		sub128( aSig, 0, term0, term1, &rem0, &rem1 );
+		while ( (sbits64) rem0 < 0 ) {
+			--zSig;
+			doubleZSig -= 2;
+			add128( rem0, rem1, zSig>>63, doubleZSig | 1, &rem0, &rem1 );
+		}
+		zSig |= ( ( rem0 | rem1 ) != 0 );
+	}
+	return roundAndPackFloat64( 0, zExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the double-precision floating-point value `a' is equal to the
+| corresponding value `b', and 0 otherwise.  The comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float64_eq( float64 a, float64 b )
+{
+	if (    ( ( extractFloat64Exp( a ) == 0x7FF ) && extractFloat64Frac( a ) )
+			|| ( ( extractFloat64Exp( b ) == 0x7FF ) && extractFloat64Frac( b ) )
+		) {
+		if ( float64_is_signaling_nan( a ) || float64_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	return ( a == b ) || ( (bits64) ( ( a | b )<<1 ) == 0 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the double-precision floating-point value `a' is less than or
+| equal to the corresponding value `b', and 0 otherwise.  The comparison is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float64_le( float64 a, float64 b )
+{
+	flag aSign, bSign;
+
+	if (    ( ( extractFloat64Exp( a ) == 0x7FF ) && extractFloat64Frac( a ) )
+			|| ( ( extractFloat64Exp( b ) == 0x7FF ) && extractFloat64Frac( b ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	aSign = extractFloat64Sign( a );
+	bSign = extractFloat64Sign( b );
+	if ( aSign != bSign ) return aSign || ( (bits64) ( ( a | b )<<1 ) == 0 );
+	return ( a == b ) || ( aSign ^ ( a < b ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the double-precision floating-point value `a' is less than
+| the corresponding value `b', and 0 otherwise.  The comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float64_lt( float64 a, float64 b )
+{
+	flag aSign, bSign;
+
+	if (    ( ( extractFloat64Exp( a ) == 0x7FF ) && extractFloat64Frac( a ) )
+			|| ( ( extractFloat64Exp( b ) == 0x7FF ) && extractFloat64Frac( b ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	aSign = extractFloat64Sign( a );
+	bSign = extractFloat64Sign( b );
+	if ( aSign != bSign ) return aSign && ( (bits64) ( ( a | b )<<1 ) != 0 );
+	return ( a != b ) && ( aSign ^ ( a < b ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the double-precision floating-point value `a' is equal to the
+| corresponding value `b', and 0 otherwise.  The invalid exception is raised
+| if either operand is a NaN.  Otherwise, the comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float64_eq_signaling( float64 a, float64 b )
+{
+	if (    ( ( extractFloat64Exp( a ) == 0x7FF ) && extractFloat64Frac( a ) )
+			|| ( ( extractFloat64Exp( b ) == 0x7FF ) && extractFloat64Frac( b ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	return ( a == b ) || ( (bits64) ( ( a | b )<<1 ) == 0 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the double-precision floating-point value `a' is less than or
+| equal to the corresponding value `b', and 0 otherwise.  Quiet NaNs do not
+| cause an exception.  Otherwise, the comparison is performed according to the
+| IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float64_le_quiet( float64 a, float64 b )
+{
+	flag aSign, bSign;
+//    int16 aExp, bExp;
+
+	if (    ( ( extractFloat64Exp( a ) == 0x7FF ) && extractFloat64Frac( a ) )
+			|| ( ( extractFloat64Exp( b ) == 0x7FF ) && extractFloat64Frac( b ) )
+		) {
+		if ( float64_is_signaling_nan( a ) || float64_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	aSign = extractFloat64Sign( a );
+	bSign = extractFloat64Sign( b );
+	if ( aSign != bSign ) return aSign || ( (bits64) ( ( a | b )<<1 ) == 0 );
+	return ( a == b ) || ( aSign ^ ( a < b ) );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the double-precision floating-point value `a' is less than
+| the corresponding value `b', and 0 otherwise.  Quiet NaNs do not cause an
+| exception.  Otherwise, the comparison is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float64_lt_quiet( float64 a, float64 b )
+{
+	flag aSign, bSign;
+
+	if (    ( ( extractFloat64Exp( a ) == 0x7FF ) && extractFloat64Frac( a ) )
+			|| ( ( extractFloat64Exp( b ) == 0x7FF ) && extractFloat64Frac( b ) )
+		) {
+		if ( float64_is_signaling_nan( a ) || float64_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	aSign = extractFloat64Sign( a );
+	bSign = extractFloat64Sign( b );
+	if ( aSign != bSign ) return aSign && ( (bits64) ( ( a | b )<<1 ) != 0 );
+	return ( a != b ) && ( aSign ^ ( a < b ) );
+
+}
+
+#ifdef FLOATX80
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the extended double-precision floating-
+| point value `a' to the 32-bit two's complement integer format.  The
+| conversion is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic---which means in particular that the conversion
+| is rounded according to the current rounding mode.  If `a' is a NaN, the
+| largest positive integer is returned.  Otherwise, if the conversion
+| overflows, the largest integer with the same sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int32 floatx80_to_int32( floatx80 a )
+{
+	flag aSign;
+	int32 aExp, shiftCount;
+	bits64 aSig;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	if ( ( aExp == 0x7FFF ) && (bits64) ( aSig<<1 ) ) aSign = 0;
+	shiftCount = 0x4037 - aExp;
+	if ( shiftCount <= 0 ) shiftCount = 1;
+	shift64RightJamming( aSig, shiftCount, &aSig );
+	return roundAndPackInt32( aSign, aSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the extended double-precision floating-
+| point value `a' to the 32-bit two's complement integer format.  The
+| conversion is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic, except that the conversion is always rounded
+| toward zero.  If `a' is a NaN, the largest positive integer is returned.
+| Otherwise, if the conversion overflows, the largest integer with the same
+| sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int32 floatx80_to_int32_round_to_zero( floatx80 a )
+{
+	flag aSign;
+	int32 aExp, shiftCount;
+	bits64 aSig, savedASig;
+	int32 z;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	if ( 0x401E < aExp ) {
+		if ( ( aExp == 0x7FFF ) && (bits64) ( aSig<<1 ) ) aSign = 0;
+		goto invalid;
+	}
+	else if ( aExp < 0x3FFF ) {
+		if ( aExp || aSig ) float_exception_flags |= float_flag_inexact;
+		return 0;
+	}
+	shiftCount = 0x403E - aExp;
+	savedASig = aSig;
+	aSig >>= shiftCount;
+	z = aSig;
+	if ( aSign ) z = - z;
+	if ( ( z < 0 ) ^ aSign ) {
+	invalid:
+		float_raise( float_flag_invalid );
+		return aSign ? (sbits32) 0x80000000 : 0x7FFFFFFF;
+	}
+	if ( ( aSig<<shiftCount ) != savedASig ) {
+		float_exception_flags |= float_flag_inexact;
+	}
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the extended double-precision floating-
+| point value `a' to the 64-bit two's complement integer format.  The
+| conversion is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic---which means in particular that the conversion
+| is rounded according to the current rounding mode.  If `a' is a NaN,
+| the largest positive integer is returned.  Otherwise, if the conversion
+| overflows, the largest integer with the same sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int64 floatx80_to_int64( floatx80 a )
+{
+	flag aSign;
+	int32 aExp, shiftCount;
+	bits64 aSig, aSigExtra;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	shiftCount = 0x403E - aExp;
+	if ( shiftCount <= 0 ) {
+		if ( shiftCount ) {
+			float_raise( float_flag_invalid );
+			if (    ! aSign
+					|| (    ( aExp == 0x7FFF )
+						&& ( aSig != LIT64( 0x8000000000000000 ) ) )
+				) {
+				return LIT64( 0x7FFFFFFFFFFFFFFF );
+			}
+			return (sbits64) LIT64( 0x8000000000000000 );
+		}
+		aSigExtra = 0;
+	}
+	else {
+		shift64ExtraRightJamming( aSig, 0, shiftCount, &aSig, &aSigExtra );
+	}
+	return roundAndPackInt64( aSign, aSig, aSigExtra );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the extended double-precision floating-
+| point value `a' to the 64-bit two's complement integer format.  The
+| conversion is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic, except that the conversion is always rounded
+| toward zero.  If `a' is a NaN, the largest positive integer is returned.
+| Otherwise, if the conversion overflows, the largest integer with the same
+| sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int64 floatx80_to_int64_round_to_zero( floatx80 a )
+{
+	flag aSign;
+	int32 aExp, shiftCount;
+	bits64 aSig;
+	int64 z;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	shiftCount = aExp - 0x403E;
+	if ( 0 <= shiftCount ) {
+		aSig &= LIT64( 0x7FFFFFFFFFFFFFFF );
+		if ( ( a.high != 0xC03E ) || aSig ) {
+			float_raise( float_flag_invalid );
+			if ( ! aSign || ( ( aExp == 0x7FFF ) && aSig ) ) {
+				return LIT64( 0x7FFFFFFFFFFFFFFF );
+			}
+		}
+		return (sbits64) LIT64( 0x8000000000000000 );
+	}
+	else if ( aExp < 0x3FFF ) {
+		if ( aExp | aSig ) float_exception_flags |= float_flag_inexact;
+		return 0;
+	}
+	z = aSig>>( - shiftCount );
+	if ( (bits64) ( aSig<<( shiftCount & 63 ) ) ) {
+		float_exception_flags |= float_flag_inexact;
+	}
+	if ( aSign ) z = - z;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the extended double-precision floating-
+| point value `a' to the single-precision floating-point format.  The
+| conversion is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 floatx80_to_float32( floatx80 a )
+{
+	flag aSign;
+	int32 aExp;
+	bits64 aSig;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	if ( aExp == 0x7FFF ) {
+		if ( (bits64) ( aSig<<1 ) ) {
+			return commonNaNToFloat32( floatx80ToCommonNaN( a ) );
+		}
+		return packFloat32( aSign, 0xFF, 0 );
+	}
+	shift64RightJamming( aSig, 33, &aSig );
+	if ( aExp || aSig ) aExp -= 0x3F81;
+	return roundAndPackFloat32( aSign, aExp, aSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the extended double-precision floating-
+| point value `a' to the double-precision floating-point format.  The
+| conversion is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 floatx80_to_float64( floatx80 a )
+{
+	flag aSign;
+	int32 aExp;
+	bits64 aSig, zSig;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	if ( aExp == 0x7FFF ) {
+		if ( (bits64) ( aSig<<1 ) ) {
+			return commonNaNToFloat64( floatx80ToCommonNaN( a ) );
+		}
+		return packFloat64( aSign, 0x7FF, 0 );
+	}
+	shift64RightJamming( aSig, 1, &zSig );
+	if ( aExp || aSig ) aExp -= 0x3C01;
+	return roundAndPackFloat64( aSign, aExp, zSig );
+
+}
+
+#ifdef FLOAT128
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the extended double-precision floating-
+| point value `a' to the quadruple-precision floating-point format.  The
+| conversion is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 floatx80_to_float128( floatx80 a )
+{
+	flag aSign;
+	int16 aExp;
+	bits64 aSig, zSig0, zSig1;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	if ( ( aExp == 0x7FFF ) && (bits64) ( aSig<<1 ) ) {
+		return commonNaNToFloat128( floatx80ToCommonNaN( a ) );
+	}
+	shift128Right( aSig<<1, 0, 16, &zSig0, &zSig1 );
+	return packFloat128( aSign, aExp, zSig0, zSig1 );
+
+}
+
+#endif
+
+/*----------------------------------------------------------------------------
+| Rounds the extended double-precision floating-point value `a' to an integer,
+| and returns the result as an extended quadruple-precision floating-point
+| value.  The operation is performed according to the IEC/IEEE Standard for
+| Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 floatx80_round_to_int( floatx80 a )
+{
+	flag aSign;
+	int32 aExp;
+	bits64 lastBitMask, roundBitsMask;
+	int8 roundingMode;
+	floatx80 z;
+
+	aExp = extractFloatx80Exp( a );
+	if ( 0x403E <= aExp ) {
+		if ( ( aExp == 0x7FFF ) && (bits64) ( extractFloatx80Frac( a )<<1 ) ) {
+			return propagateFloatx80NaN( a, a );
+		}
+		return a;
+	}
+	if ( aExp < 0x3FFF ) {
+		if (    ( aExp == 0 )
+				&& ( (bits64) ( extractFloatx80Frac( a )<<1 ) == 0 ) ) {
+			return a;
+		}
+		float_exception_flags |= float_flag_inexact;
+		aSign = extractFloatx80Sign( a );
+		switch ( float_rounding_mode ) {
+			case float_round_nearest_even:
+			if ( ( aExp == 0x3FFE ) && (bits64) ( extractFloatx80Frac( a )<<1 )
+				) {
+				return
+					packFloatx80( aSign, 0x3FFF, LIT64( 0x8000000000000000 ) );
+			}
+			break;
+			case float_round_down:
+			return
+					aSign ?
+						packFloatx80( 1, 0x3FFF, LIT64( 0x8000000000000000 ) )
+				: packFloatx80( 0, 0, 0 );
+			case float_round_up:
+			return
+					aSign ? packFloatx80( 1, 0, 0 )
+				: packFloatx80( 0, 0x3FFF, LIT64( 0x8000000000000000 ) );
+		}
+		return packFloatx80( aSign, 0, 0 );
+	}
+	lastBitMask = 1;
+	lastBitMask <<= 0x403E - aExp;
+	roundBitsMask = lastBitMask - 1;
+	z = a;
+	roundingMode = float_rounding_mode;
+	if ( roundingMode == float_round_nearest_even ) {
+		z.low += lastBitMask>>1;
+		if ( ( z.low & roundBitsMask ) == 0 ) z.low &= ~ lastBitMask;
+	}
+	else if ( roundingMode != float_round_to_zero ) {
+		if ( extractFloatx80Sign( z ) ^ ( roundingMode == float_round_up ) ) {
+			z.low += roundBitsMask;
+		}
+	}
+	z.low &= ~ roundBitsMask;
+	if ( z.low == 0 ) {
+		++z.high;
+		z.low = LIT64( 0x8000000000000000 );
+	}
+	if ( z.low != a.low ) float_exception_flags |= float_flag_inexact;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of adding the absolute values of the extended double-
+| precision floating-point values `a' and `b'.  If `zSign' is 1, the sum is
+| negated before being returned.  `zSign' is ignored if the result is a NaN.
+| The addition is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static floatx80 addFloatx80Sigs( floatx80 a, floatx80 b, flag zSign )
+{
+	int32 aExp, bExp, zExp;
+	bits64 aSig, bSig, zSig0, zSig1;
+	int32 expDiff;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	bSig = extractFloatx80Frac( b );
+	bExp = extractFloatx80Exp( b );
+	expDiff = aExp - bExp;
+	if ( 0 < expDiff ) {
+		if ( aExp == 0x7FFF ) {
+			if ( (bits64) ( aSig<<1 ) ) return propagateFloatx80NaN( a, b );
+			return a;
+		}
+		if ( bExp == 0 ) --expDiff;
+		shift64ExtraRightJamming( bSig, 0, expDiff, &bSig, &zSig1 );
+		zExp = aExp;
+	}
+	else if ( expDiff < 0 ) {
+		if ( bExp == 0x7FFF ) {
+			if ( (bits64) ( bSig<<1 ) ) return propagateFloatx80NaN( a, b );
+			return packFloatx80( zSign, 0x7FFF, LIT64( 0x8000000000000000 ) );
+		}
+		if ( aExp == 0 ) ++expDiff;
+		shift64ExtraRightJamming( aSig, 0, - expDiff, &aSig, &zSig1 );
+		zExp = bExp;
+	}
+	else {
+		if ( aExp == 0x7FFF ) {
+			if ( (bits64) ( ( aSig | bSig )<<1 ) ) {
+				return propagateFloatx80NaN( a, b );
+			}
+			return a;
+		}
+		zSig1 = 0;
+		zSig0 = aSig + bSig;
+		if ( aExp == 0 ) {
+			normalizeFloatx80Subnormal( zSig0, &zExp, &zSig0 );
+			goto roundAndPack;
+		}
+		zExp = aExp;
+		goto shiftRight1;
+	}
+	zSig0 = aSig + bSig;
+	if ( (sbits64) zSig0 < 0 ) goto roundAndPack;
+	shiftRight1:
+	shift64ExtraRightJamming( zSig0, zSig1, 1, &zSig0, &zSig1 );
+	zSig0 |= LIT64( 0x8000000000000000 );
+	++zExp;
+	roundAndPack:
+	return
+		roundAndPackFloatx80(
+			floatx80_rounding_precision, zSign, zExp, zSig0, zSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of subtracting the absolute values of the extended
+| double-precision floating-point values `a' and `b'.  If `zSign' is 1, the
+| difference is negated before being returned.  `zSign' is ignored if the
+| result is a NaN.  The subtraction is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static floatx80 subFloatx80Sigs( floatx80 a, floatx80 b, flag zSign )
+{
+	int32 aExp, bExp, zExp;
+	bits64 aSig, bSig, zSig0, zSig1;
+	int32 expDiff;
+	floatx80 z;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	bSig = extractFloatx80Frac( b );
+	bExp = extractFloatx80Exp( b );
+	expDiff = aExp - bExp;
+	if ( 0 < expDiff ) goto aExpBigger;
+	if ( expDiff < 0 ) goto bExpBigger;
+	if ( aExp == 0x7FFF ) {
+		if ( (bits64) ( ( aSig | bSig )<<1 ) ) {
+			return propagateFloatx80NaN( a, b );
+		}
+		float_raise( float_flag_invalid );
+		z.low = floatx80_default_nan_low;
+		z.high = floatx80_default_nan_high;
+		return z;
+	}
+	if ( aExp == 0 ) {
+		aExp = 1;
+		bExp = 1;
+	}
+	zSig1 = 0;
+	if ( bSig < aSig ) goto aBigger;
+	if ( aSig < bSig ) goto bBigger;
+	return packFloatx80( float_rounding_mode == float_round_down, 0, 0 );
+	bExpBigger:
+	if ( bExp == 0x7FFF ) {
+		if ( (bits64) ( bSig<<1 ) ) return propagateFloatx80NaN( a, b );
+		return packFloatx80( zSign ^ 1, 0x7FFF, LIT64( 0x8000000000000000 ) );
+	}
+	if ( aExp == 0 ) ++expDiff;
+	shift128RightJamming( aSig, 0, - expDiff, &aSig, &zSig1 );
+	bBigger:
+	sub128( bSig, 0, aSig, zSig1, &zSig0, &zSig1 );
+	zExp = bExp;
+	zSign ^= 1;
+	goto normalizeRoundAndPack;
+	aExpBigger:
+	if ( aExp == 0x7FFF ) {
+		if ( (bits64) ( aSig<<1 ) ) return propagateFloatx80NaN( a, b );
+		return a;
+	}
+	if ( bExp == 0 ) --expDiff;
+	shift128RightJamming( bSig, 0, expDiff, &bSig, &zSig1 );
+	aBigger:
+	sub128( aSig, 0, bSig, zSig1, &zSig0, &zSig1 );
+	zExp = aExp;
+	normalizeRoundAndPack:
+	return
+		normalizeRoundAndPackFloatx80(
+			floatx80_rounding_precision, zSign, zExp, zSig0, zSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of adding the extended double-precision floating-point
+| values `a' and `b'.  The operation is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 floatx80_add( floatx80 a, floatx80 b )
+{
+	flag aSign, bSign;
+
+	aSign = extractFloatx80Sign( a );
+	bSign = extractFloatx80Sign( b );
+	if ( aSign == bSign ) {
+		return addFloatx80Sigs( a, b, aSign );
+	}
+	else {
+		return subFloatx80Sigs( a, b, aSign );
+	}
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of subtracting the extended double-precision floating-
+| point values `a' and `b'.  The operation is performed according to the
+| IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 floatx80_sub( floatx80 a, floatx80 b )
+{
+	flag aSign, bSign;
+
+	aSign = extractFloatx80Sign( a );
+	bSign = extractFloatx80Sign( b );
+	if ( aSign == bSign ) {
+		return subFloatx80Sigs( a, b, aSign );
+	}
+	else {
+		return addFloatx80Sigs( a, b, aSign );
+	}
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of multiplying the extended double-precision floating-
+| point values `a' and `b'.  The operation is performed according to the
+| IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 floatx80_mul( floatx80 a, floatx80 b )
+{
+	flag aSign, bSign, zSign;
+	int32 aExp, bExp, zExp;
+	bits64 aSig, bSig, zSig0, zSig1;
+	floatx80 z;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	bSig = extractFloatx80Frac( b );
+	bExp = extractFloatx80Exp( b );
+	bSign = extractFloatx80Sign( b );
+	zSign = aSign ^ bSign;
+	if ( aExp == 0x7FFF ) {
+		if (    (bits64) ( aSig<<1 )
+				|| ( ( bExp == 0x7FFF ) && (bits64) ( bSig<<1 ) ) ) {
+			return propagateFloatx80NaN( a, b );
+		}
+		if ( ( bExp | bSig ) == 0 ) goto invalid;
+		return packFloatx80( zSign, 0x7FFF, LIT64( 0x8000000000000000 ) );
+	}
+	if ( bExp == 0x7FFF ) {
+		if ( (bits64) ( bSig<<1 ) ) return propagateFloatx80NaN( a, b );
+		if ( ( aExp | aSig ) == 0 ) {
+	invalid:
+			float_raise( float_flag_invalid );
+			z.low = floatx80_default_nan_low;
+			z.high = floatx80_default_nan_high;
+			return z;
+		}
+		return packFloatx80( zSign, 0x7FFF, LIT64( 0x8000000000000000 ) );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloatx80( zSign, 0, 0 );
+		normalizeFloatx80Subnormal( aSig, &aExp, &aSig );
+	}
+	if ( bExp == 0 ) {
+		if ( bSig == 0 ) return packFloatx80( zSign, 0, 0 );
+		normalizeFloatx80Subnormal( bSig, &bExp, &bSig );
+	}
+	zExp = aExp + bExp - 0x3FFE;
+	mul64To128( aSig, bSig, &zSig0, &zSig1 );
+	if ( 0 < (sbits64) zSig0 ) {
+		shortShift128Left( zSig0, zSig1, 1, &zSig0, &zSig1 );
+		--zExp;
+	}
+	return
+		roundAndPackFloatx80(
+			floatx80_rounding_precision, zSign, zExp, zSig0, zSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of dividing the extended double-precision floating-point
+| value `a' by the corresponding value `b'.  The operation is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 floatx80_div( floatx80 a, floatx80 b )
+{
+	flag aSign, bSign, zSign;
+	int32 aExp, bExp, zExp;
+	bits64 aSig, bSig, zSig0, zSig1;
+	bits64 rem0, rem1, rem2, term0, term1, term2;
+	floatx80 z;
+
+	aSig = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	bSig = extractFloatx80Frac( b );
+	bExp = extractFloatx80Exp( b );
+	bSign = extractFloatx80Sign( b );
+	zSign = aSign ^ bSign;
+	if ( aExp == 0x7FFF ) {
+		if ( (bits64) ( aSig<<1 ) ) return propagateFloatx80NaN( a, b );
+		if ( bExp == 0x7FFF ) {
+			if ( (bits64) ( bSig<<1 ) ) return propagateFloatx80NaN( a, b );
+			goto invalid;
+		}
+		return packFloatx80( zSign, 0x7FFF, LIT64( 0x8000000000000000 ) );
+	}
+	if ( bExp == 0x7FFF ) {
+		if ( (bits64) ( bSig<<1 ) ) return propagateFloatx80NaN( a, b );
+		return packFloatx80( zSign, 0, 0 );
+	}
+	if ( bExp == 0 ) {
+		if ( bSig == 0 ) {
+			if ( ( aExp | aSig ) == 0 ) {
+	invalid:
+				float_raise( float_flag_invalid );
+				z.low = floatx80_default_nan_low;
+				z.high = floatx80_default_nan_high;
+				return z;
+			}
+			float_raise( float_flag_divbyzero );
+			return packFloatx80( zSign, 0x7FFF, LIT64( 0x8000000000000000 ) );
+		}
+		normalizeFloatx80Subnormal( bSig, &bExp, &bSig );
+	}
+	if ( aExp == 0 ) {
+		if ( aSig == 0 ) return packFloatx80( zSign, 0, 0 );
+		normalizeFloatx80Subnormal( aSig, &aExp, &aSig );
+	}
+	zExp = aExp - bExp + 0x3FFE;
+	rem1 = 0;
+	if ( bSig <= aSig ) {
+		shift128Right( aSig, 0, 1, &aSig, &rem1 );
+		++zExp;
+	}
+	zSig0 = estimateDiv128To64( aSig, rem1, bSig );
+	mul64To128( bSig, zSig0, &term0, &term1 );
+	sub128( aSig, rem1, term0, term1, &rem0, &rem1 );
+	while ( (sbits64) rem0 < 0 ) {
+		--zSig0;
+		add128( rem0, rem1, 0, bSig, &rem0, &rem1 );
+	}
+	zSig1 = estimateDiv128To64( rem1, 0, bSig );
+	if ( (bits64) ( zSig1<<1 ) <= 8 ) {
+		mul64To128( bSig, zSig1, &term1, &term2 );
+		sub128( rem1, 0, term1, term2, &rem1, &rem2 );
+		while ( (sbits64) rem1 < 0 ) {
+			--zSig1;
+			add128( rem1, rem2, 0, bSig, &rem1, &rem2 );
+		}
+		zSig1 |= ( ( rem1 | rem2 ) != 0 );
+	}
+	return
+		roundAndPackFloatx80(
+			floatx80_rounding_precision, zSign, zExp, zSig0, zSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the remainder of the extended double-precision floating-point value
+| `a' with respect to the corresponding value `b'.  The operation is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 floatx80_rem( floatx80 a, floatx80 b )
+{
+	flag aSign, zSign;
+	int32 aExp, bExp, expDiff;
+	bits64 aSig0, aSig1, bSig;
+	bits64 q, term0, term1, alternateASig0, alternateASig1;
+	floatx80 z;
+
+	aSig0 = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	bSig = extractFloatx80Frac( b );
+	bExp = extractFloatx80Exp( b );
+//    bSign = extractFloatx80Sign( b );
+	if ( aExp == 0x7FFF ) {
+		if (    (bits64) ( aSig0<<1 )
+				|| ( ( bExp == 0x7FFF ) && (bits64) ( bSig<<1 ) ) ) {
+			return propagateFloatx80NaN( a, b );
+		}
+		goto invalid;
+	}
+	if ( bExp == 0x7FFF ) {
+		if ( (bits64) ( bSig<<1 ) ) return propagateFloatx80NaN( a, b );
+		return a;
+	}
+	if ( bExp == 0 ) {
+		if ( bSig == 0 ) {
+	invalid:
+			float_raise( float_flag_invalid );
+			z.low = floatx80_default_nan_low;
+			z.high = floatx80_default_nan_high;
+			return z;
+		}
+		normalizeFloatx80Subnormal( bSig, &bExp, &bSig );
+	}
+	if ( aExp == 0 ) {
+		if ( (bits64) ( aSig0<<1 ) == 0 ) return a;
+		normalizeFloatx80Subnormal( aSig0, &aExp, &aSig0 );
+	}
+	bSig |= LIT64( 0x8000000000000000 );
+	zSign = aSign;
+	expDiff = aExp - bExp;
+	aSig1 = 0;
+	if ( expDiff < 0 ) {
+		if ( expDiff < -1 ) return a;
+		shift128Right( aSig0, 0, 1, &aSig0, &aSig1 );
+		expDiff = 0;
+	}
+	q = ( bSig <= aSig0 );
+	if ( q ) aSig0 -= bSig;
+	expDiff -= 64;
+	while ( 0 < expDiff ) {
+		q = estimateDiv128To64( aSig0, aSig1, bSig );
+		q = ( 2 < q ) ? q - 2 : 0;
+		mul64To128( bSig, q, &term0, &term1 );
+		sub128( aSig0, aSig1, term0, term1, &aSig0, &aSig1 );
+		shortShift128Left( aSig0, aSig1, 62, &aSig0, &aSig1 );
+		expDiff -= 62;
+	}
+	expDiff += 64;
+	if ( 0 < expDiff ) {
+		q = estimateDiv128To64( aSig0, aSig1, bSig );
+		q = ( 2 < q ) ? q - 2 : 0;
+		q >>= 64 - expDiff;
+		mul64To128( bSig, q<<( 64 - expDiff ), &term0, &term1 );
+		sub128( aSig0, aSig1, term0, term1, &aSig0, &aSig1 );
+		shortShift128Left( 0, bSig, 64 - expDiff, &term0, &term1 );
+		while ( le128( term0, term1, aSig0, aSig1 ) ) {
+			++q;
+			sub128( aSig0, aSig1, term0, term1, &aSig0, &aSig1 );
+		}
+	}
+	else {
+		term1 = 0;
+		term0 = bSig;
+	}
+	sub128( term0, term1, aSig0, aSig1, &alternateASig0, &alternateASig1 );
+	if (    lt128( alternateASig0, alternateASig1, aSig0, aSig1 )
+			|| (    eq128( alternateASig0, alternateASig1, aSig0, aSig1 )
+				&& ( q & 1 ) )
+		) {
+		aSig0 = alternateASig0;
+		aSig1 = alternateASig1;
+		zSign = ! zSign;
+	}
+	return
+		normalizeRoundAndPackFloatx80(
+			80, zSign, bExp + expDiff, aSig0, aSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the square root of the extended double-precision floating-point
+| value `a'.  The operation is performed according to the IEC/IEEE Standard
+| for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 floatx80_sqrt( floatx80 a )
+{
+	flag aSign;
+	int32 aExp, zExp;
+	bits64 aSig0, aSig1, zSig0, zSig1, doubleZSig0;
+	bits64 rem0, rem1, rem2, rem3, term0, term1, term2, term3;
+	floatx80 z;
+
+	aSig0 = extractFloatx80Frac( a );
+	aExp = extractFloatx80Exp( a );
+	aSign = extractFloatx80Sign( a );
+	if ( aExp == 0x7FFF ) {
+		if ( (bits64) ( aSig0<<1 ) ) return propagateFloatx80NaN( a, a );
+		if ( ! aSign ) return a;
+		goto invalid;
+	}
+	if ( aSign ) {
+		if ( ( aExp | aSig0 ) == 0 ) return a;
+	invalid:
+		float_raise( float_flag_invalid );
+		z.low = floatx80_default_nan_low;
+		z.high = floatx80_default_nan_high;
+		return z;
+	}
+	if ( aExp == 0 ) {
+		if ( aSig0 == 0 ) return packFloatx80( 0, 0, 0 );
+		normalizeFloatx80Subnormal( aSig0, &aExp, &aSig0 );
+	}
+	zExp = ( ( aExp - 0x3FFF )>>1 ) + 0x3FFF;
+	zSig0 = estimateSqrt32( aExp, aSig0>>32 );
+	shift128Right( aSig0, 0, 2 + ( aExp & 1 ), &aSig0, &aSig1 );
+	zSig0 = estimateDiv128To64( aSig0, aSig1, zSig0<<32 ) + ( zSig0<<30 );
+	doubleZSig0 = zSig0<<1;
+	mul64To128( zSig0, zSig0, &term0, &term1 );
+	sub128( aSig0, aSig1, term0, term1, &rem0, &rem1 );
+	while ( (sbits64) rem0 < 0 ) {
+		--zSig0;
+		doubleZSig0 -= 2;
+		add128( rem0, rem1, zSig0>>63, doubleZSig0 | 1, &rem0, &rem1 );
+	}
+	zSig1 = estimateDiv128To64( rem1, 0, doubleZSig0 );
+	if ( ( zSig1 & LIT64( 0x3FFFFFFFFFFFFFFF ) ) <= 5 ) {
+		if ( zSig1 == 0 ) zSig1 = 1;
+		mul64To128( doubleZSig0, zSig1, &term1, &term2 );
+		sub128( rem1, 0, term1, term2, &rem1, &rem2 );
+		mul64To128( zSig1, zSig1, &term2, &term3 );
+		sub192( rem1, rem2, 0, 0, term2, term3, &rem1, &rem2, &rem3 );
+		while ( (sbits64) rem1 < 0 ) {
+			--zSig1;
+			shortShift128Left( 0, zSig1, 1, &term2, &term3 );
+			term3 |= 1;
+			term2 |= doubleZSig0;
+			add192( rem1, rem2, rem3, 0, term2, term3, &rem1, &rem2, &rem3 );
+		}
+		zSig1 |= ( ( rem1 | rem2 | rem3 ) != 0 );
+	}
+	shortShift128Left( 0, zSig1, 1, &zSig0, &zSig1 );
+	zSig0 |= doubleZSig0;
+	return
+		roundAndPackFloatx80(
+			floatx80_rounding_precision, 0, zExp, zSig0, zSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the extended double-precision floating-point value `a' is
+| equal to the corresponding value `b', and 0 otherwise.  The comparison is
+| performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag floatx80_eq( floatx80 a, floatx80 b )
+{
+	if (    (    ( extractFloatx80Exp( a ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( a )<<1 ) )
+			|| (    ( extractFloatx80Exp( b ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( b )<<1 ) )
+		) {
+		if (    floatx80_is_signaling_nan( a )
+				|| floatx80_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	return
+			( a.low == b.low )
+		&& (    ( a.high == b.high )
+				|| (    ( a.low == 0 )
+					&& ( (bits16) ( ( a.high | b.high )<<1 ) == 0 ) )
+			);
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the extended double-precision floating-point value `a' is
+| less than or equal to the corresponding value `b', and 0 otherwise.  The
+| comparison is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag floatx80_le( floatx80 a, floatx80 b )
+{
+	flag aSign, bSign;
+
+	if (    (    ( extractFloatx80Exp( a ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( a )<<1 ) )
+			|| (    ( extractFloatx80Exp( b ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( b )<<1 ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	aSign = extractFloatx80Sign( a );
+	bSign = extractFloatx80Sign( b );
+	if ( aSign != bSign ) {
+		return
+				aSign
+			|| (    ( ( (bits16) ( ( a.high | b.high )<<1 ) ) | a.low | b.low )
+					== 0 );
+	}
+	return
+			aSign ? le128( b.high, b.low, a.high, a.low )
+		: le128( a.high, a.low, b.high, b.low );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the extended double-precision floating-point value `a' is
+| less than the corresponding value `b', and 0 otherwise.  The comparison
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag floatx80_lt( floatx80 a, floatx80 b )
+{
+	flag aSign, bSign;
+
+	if (    (    ( extractFloatx80Exp( a ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( a )<<1 ) )
+			|| (    ( extractFloatx80Exp( b ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( b )<<1 ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	aSign = extractFloatx80Sign( a );
+	bSign = extractFloatx80Sign( b );
+	if ( aSign != bSign ) {
+		return
+				aSign
+			&& (    ( ( (bits16) ( ( a.high | b.high )<<1 ) ) | a.low | b.low )
+					!= 0 );
+	}
+	return
+			aSign ? lt128( b.high, b.low, a.high, a.low )
+		: lt128( a.high, a.low, b.high, b.low );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the extended double-precision floating-point value `a' is equal
+| to the corresponding value `b', and 0 otherwise.  The invalid exception is
+| raised if either operand is a NaN.  Otherwise, the comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag floatx80_eq_signaling( floatx80 a, floatx80 b )
+{
+	if (    (    ( extractFloatx80Exp( a ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( a )<<1 ) )
+			|| (    ( extractFloatx80Exp( b ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( b )<<1 ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	return
+			( a.low == b.low )
+		&& (    ( a.high == b.high )
+				|| (    ( a.low == 0 )
+					&& ( (bits16) ( ( a.high | b.high )<<1 ) == 0 ) )
+			);
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the extended double-precision floating-point value `a' is less
+| than or equal to the corresponding value `b', and 0 otherwise.  Quiet NaNs
+| do not cause an exception.  Otherwise, the comparison is performed according
+| to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag floatx80_le_quiet( floatx80 a, floatx80 b )
+{
+	flag aSign, bSign;
+
+	if (    (    ( extractFloatx80Exp( a ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( a )<<1 ) )
+			|| (    ( extractFloatx80Exp( b ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( b )<<1 ) )
+		) {
+		if (    floatx80_is_signaling_nan( a )
+				|| floatx80_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	aSign = extractFloatx80Sign( a );
+	bSign = extractFloatx80Sign( b );
+	if ( aSign != bSign ) {
+		return
+				aSign
+			|| (    ( ( (bits16) ( ( a.high | b.high )<<1 ) ) | a.low | b.low )
+					== 0 );
+	}
+	return
+			aSign ? le128( b.high, b.low, a.high, a.low )
+		: le128( a.high, a.low, b.high, b.low );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the extended double-precision floating-point value `a' is less
+| than the corresponding value `b', and 0 otherwise.  Quiet NaNs do not cause
+| an exception.  Otherwise, the comparison is performed according to the
+| IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag floatx80_lt_quiet( floatx80 a, floatx80 b )
+{
+	flag aSign, bSign;
+
+	if (    (    ( extractFloatx80Exp( a ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( a )<<1 ) )
+			|| (    ( extractFloatx80Exp( b ) == 0x7FFF )
+				&& (bits64) ( extractFloatx80Frac( b )<<1 ) )
+		) {
+		if (    floatx80_is_signaling_nan( a )
+				|| floatx80_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	aSign = extractFloatx80Sign( a );
+	bSign = extractFloatx80Sign( b );
+	if ( aSign != bSign ) {
+		return
+				aSign
+			&& (    ( ( (bits16) ( ( a.high | b.high )<<1 ) ) | a.low | b.low )
+					!= 0 );
+	}
+	return
+			aSign ? lt128( b.high, b.low, a.high, a.low )
+		: lt128( a.high, a.low, b.high, b.low );
+
+}
+
+#endif
+
+#ifdef FLOAT128
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the quadruple-precision floating-point
+| value `a' to the 32-bit two's complement integer format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic---which means in particular that the conversion is rounded
+| according to the current rounding mode.  If `a' is a NaN, the largest
+| positive integer is returned.  Otherwise, if the conversion overflows, the
+| largest integer with the same sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int32 float128_to_int32( float128 a )
+{
+	flag aSign;
+	int32 aExp, shiftCount;
+	bits64 aSig0, aSig1;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	if ( ( aExp == 0x7FFF ) && ( aSig0 | aSig1 ) ) aSign = 0;
+	if ( aExp ) aSig0 |= LIT64( 0x0001000000000000 );
+	aSig0 |= ( aSig1 != 0 );
+	shiftCount = 0x4028 - aExp;
+	if ( 0 < shiftCount ) shift64RightJamming( aSig0, shiftCount, &aSig0 );
+	return roundAndPackInt32( aSign, aSig0 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the quadruple-precision floating-point
+| value `a' to the 32-bit two's complement integer format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic, except that the conversion is always rounded toward zero.  If
+| `a' is a NaN, the largest positive integer is returned.  Otherwise, if the
+| conversion overflows, the largest integer with the same sign as `a' is
+| returned.
+*----------------------------------------------------------------------------*/
+
+int32 float128_to_int32_round_to_zero( float128 a )
+{
+	flag aSign;
+	int32 aExp, shiftCount;
+	bits64 aSig0, aSig1, savedASig;
+	int32 z;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	aSig0 |= ( aSig1 != 0 );
+	if ( 0x401E < aExp ) {
+		if ( ( aExp == 0x7FFF ) && aSig0 ) aSign = 0;
+		goto invalid;
+	}
+	else if ( aExp < 0x3FFF ) {
+		if ( aExp || aSig0 ) float_exception_flags |= float_flag_inexact;
+		return 0;
+	}
+	aSig0 |= LIT64( 0x0001000000000000 );
+	shiftCount = 0x402F - aExp;
+	savedASig = aSig0;
+	aSig0 >>= shiftCount;
+	z = aSig0;
+	if ( aSign ) z = - z;
+	if ( ( z < 0 ) ^ aSign ) {
+	invalid:
+		float_raise( float_flag_invalid );
+		return aSign ? (sbits32) 0x80000000 : 0x7FFFFFFF;
+	}
+	if ( ( aSig0<<shiftCount ) != savedASig ) {
+		float_exception_flags |= float_flag_inexact;
+	}
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the quadruple-precision floating-point
+| value `a' to the 64-bit two's complement integer format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic---which means in particular that the conversion is rounded
+| according to the current rounding mode.  If `a' is a NaN, the largest
+| positive integer is returned.  Otherwise, if the conversion overflows, the
+| largest integer with the same sign as `a' is returned.
+*----------------------------------------------------------------------------*/
+
+int64 float128_to_int64( float128 a )
+{
+	flag aSign;
+	int32 aExp, shiftCount;
+	bits64 aSig0, aSig1;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	if ( aExp ) aSig0 |= LIT64( 0x0001000000000000 );
+	shiftCount = 0x402F - aExp;
+	if ( shiftCount <= 0 ) {
+		if ( 0x403E < aExp ) {
+			float_raise( float_flag_invalid );
+			if (    ! aSign
+					|| (    ( aExp == 0x7FFF )
+						&& ( aSig1 || ( aSig0 != LIT64( 0x0001000000000000 ) ) )
+					)
+				) {
+				return LIT64( 0x7FFFFFFFFFFFFFFF );
+			}
+			return (sbits64) LIT64( 0x8000000000000000 );
+		}
+		shortShift128Left( aSig0, aSig1, - shiftCount, &aSig0, &aSig1 );
+	}
+	else {
+		shift64ExtraRightJamming( aSig0, aSig1, shiftCount, &aSig0, &aSig1 );
+	}
+	return roundAndPackInt64( aSign, aSig0, aSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the quadruple-precision floating-point
+| value `a' to the 64-bit two's complement integer format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic, except that the conversion is always rounded toward zero.
+| If `a' is a NaN, the largest positive integer is returned.  Otherwise, if
+| the conversion overflows, the largest integer with the same sign as `a' is
+| returned.
+*----------------------------------------------------------------------------*/
+
+int64 float128_to_int64_round_to_zero( float128 a )
+{
+	flag aSign;
+	int32 aExp, shiftCount;
+	bits64 aSig0, aSig1;
+	int64 z;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	if ( aExp ) aSig0 |= LIT64( 0x0001000000000000 );
+	shiftCount = aExp - 0x402F;
+	if ( 0 < shiftCount ) {
+		if ( 0x403E <= aExp ) {
+			aSig0 &= LIT64( 0x0000FFFFFFFFFFFF );
+			if (    ( a.high == LIT64( 0xC03E000000000000 ) )
+					&& ( aSig1 < LIT64( 0x0002000000000000 ) ) ) {
+				if ( aSig1 ) float_exception_flags |= float_flag_inexact;
+			}
+			else {
+				float_raise( float_flag_invalid );
+				if ( ! aSign || ( ( aExp == 0x7FFF ) && ( aSig0 | aSig1 ) ) ) {
+					return LIT64( 0x7FFFFFFFFFFFFFFF );
+				}
+			}
+			return (sbits64) LIT64( 0x8000000000000000 );
+		}
+		z = ( aSig0<<shiftCount ) | ( aSig1>>( ( - shiftCount ) & 63 ) );
+		if ( (bits64) ( aSig1<<shiftCount ) ) {
+			float_exception_flags |= float_flag_inexact;
+		}
+	}
+	else {
+		if ( aExp < 0x3FFF ) {
+			if ( aExp | aSig0 | aSig1 ) {
+				float_exception_flags |= float_flag_inexact;
+			}
+			return 0;
+		}
+		z = aSig0>>( - shiftCount );
+		if (    aSig1
+				|| ( shiftCount && (bits64) ( aSig0<<( shiftCount & 63 ) ) ) ) {
+			float_exception_flags |= float_flag_inexact;
+		}
+	}
+	if ( aSign ) z = - z;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the quadruple-precision floating-point
+| value `a' to the single-precision floating-point format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float32 float128_to_float32( float128 a )
+{
+	flag aSign;
+	int32 aExp;
+	bits64 aSig0, aSig1;
+	bits32 zSig;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	if ( aExp == 0x7FFF ) {
+		if ( aSig0 | aSig1 ) {
+			return commonNaNToFloat32( float128ToCommonNaN( a ) );
+		}
+		return packFloat32( aSign, 0xFF, 0 );
+	}
+	aSig0 |= ( aSig1 != 0 );
+	shift64RightJamming( aSig0, 18, &aSig0 );
+	zSig = aSig0;
+	if ( aExp || zSig ) {
+		zSig |= 0x40000000;
+		aExp -= 0x3F81;
+	}
+	return roundAndPackFloat32( aSign, aExp, zSig );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the quadruple-precision floating-point
+| value `a' to the double-precision floating-point format.  The conversion
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float64 float128_to_float64( float128 a )
+{
+	flag aSign;
+	int32 aExp;
+	bits64 aSig0, aSig1;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	if ( aExp == 0x7FFF ) {
+		if ( aSig0 | aSig1 ) {
+			return commonNaNToFloat64( float128ToCommonNaN( a ) );
+		}
+		return packFloat64( aSign, 0x7FF, 0 );
+	}
+	shortShift128Left( aSig0, aSig1, 14, &aSig0, &aSig1 );
+	aSig0 |= ( aSig1 != 0 );
+	if ( aExp || aSig0 ) {
+		aSig0 |= LIT64( 0x4000000000000000 );
+		aExp -= 0x3C01;
+	}
+	return roundAndPackFloat64( aSign, aExp, aSig0 );
+
+}
+
+#ifdef FLOATX80
+
+/*----------------------------------------------------------------------------
+| Returns the result of converting the quadruple-precision floating-point
+| value `a' to the extended double-precision floating-point format.  The
+| conversion is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+floatx80 float128_to_floatx80( float128 a )
+{
+	flag aSign;
+	int32 aExp;
+	bits64 aSig0, aSig1;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	if ( aExp == 0x7FFF ) {
+		if ( aSig0 | aSig1 ) {
+			return commonNaNToFloatx80( float128ToCommonNaN( a ) );
+		}
+		return packFloatx80( aSign, 0x7FFF, LIT64( 0x8000000000000000 ) );
+	}
+	if ( aExp == 0 ) {
+		if ( ( aSig0 | aSig1 ) == 0 ) return packFloatx80( aSign, 0, 0 );
+		normalizeFloat128Subnormal( aSig0, aSig1, &aExp, &aSig0, &aSig1 );
+	}
+	else {
+		aSig0 |= LIT64( 0x0001000000000000 );
+	}
+	shortShift128Left( aSig0, aSig1, 15, &aSig0, &aSig1 );
+	return roundAndPackFloatx80( 80, aSign, aExp, aSig0, aSig1 );
+
+}
+
+#endif
+
+/*----------------------------------------------------------------------------
+| Rounds the quadruple-precision floating-point value `a' to an integer, and
+| returns the result as a quadruple-precision floating-point value.  The
+| operation is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 float128_round_to_int( float128 a )
+{
+	flag aSign;
+	int32 aExp;
+	bits64 lastBitMask, roundBitsMask;
+	int8 roundingMode;
+	float128 z;
+
+	aExp = extractFloat128Exp( a );
+	if ( 0x402F <= aExp ) {
+		if ( 0x406F <= aExp ) {
+			if (    ( aExp == 0x7FFF )
+					&& ( extractFloat128Frac0( a ) | extractFloat128Frac1( a ) )
+				) {
+				return propagateFloat128NaN( a, a );
+			}
+			return a;
+		}
+		lastBitMask = 1;
+		lastBitMask = ( lastBitMask<<( 0x406E - aExp ) )<<1;
+		roundBitsMask = lastBitMask - 1;
+		z = a;
+		roundingMode = float_rounding_mode;
+		if ( roundingMode == float_round_nearest_even ) {
+			if ( lastBitMask ) {
+				add128( z.high, z.low, 0, lastBitMask>>1, &z.high, &z.low );
+				if ( ( z.low & roundBitsMask ) == 0 ) z.low &= ~ lastBitMask;
+			}
+			else {
+				if ( (sbits64) z.low < 0 ) {
+					++z.high;
+					if ( (bits64) ( z.low<<1 ) == 0 ) z.high &= ~1;
+				}
+			}
+		}
+		else if ( roundingMode != float_round_to_zero ) {
+			if (   extractFloat128Sign( z )
+					^ ( roundingMode == float_round_up ) ) {
+				add128( z.high, z.low, 0, roundBitsMask, &z.high, &z.low );
+			}
+		}
+		z.low &= ~ roundBitsMask;
+	}
+	else {
+		if ( aExp < 0x3FFF ) {
+			if ( ( ( (bits64) ( a.high<<1 ) ) | a.low ) == 0 ) return a;
+			float_exception_flags |= float_flag_inexact;
+			aSign = extractFloat128Sign( a );
+			switch ( float_rounding_mode ) {
+				case float_round_nearest_even:
+				if (    ( aExp == 0x3FFE )
+						&& (   extractFloat128Frac0( a )
+							| extractFloat128Frac1( a ) )
+					) {
+					return packFloat128( aSign, 0x3FFF, 0, 0 );
+				}
+				break;
+				case float_round_down:
+				return
+						aSign ? packFloat128( 1, 0x3FFF, 0, 0 )
+					: packFloat128( 0, 0, 0, 0 );
+				case float_round_up:
+				return
+						aSign ? packFloat128( 1, 0, 0, 0 )
+					: packFloat128( 0, 0x3FFF, 0, 0 );
+			}
+			return packFloat128( aSign, 0, 0, 0 );
+		}
+		lastBitMask = 1;
+		lastBitMask <<= 0x402F - aExp;
+		roundBitsMask = lastBitMask - 1;
+		z.low = 0;
+		z.high = a.high;
+		roundingMode = float_rounding_mode;
+		if ( roundingMode == float_round_nearest_even ) {
+			z.high += lastBitMask>>1;
+			if ( ( ( z.high & roundBitsMask ) | a.low ) == 0 ) {
+				z.high &= ~ lastBitMask;
+			}
+		}
+		else if ( roundingMode != float_round_to_zero ) {
+			if (   extractFloat128Sign( z )
+					^ ( roundingMode == float_round_up ) ) {
+				z.high |= ( a.low != 0 );
+				z.high += roundBitsMask;
+			}
+		}
+		z.high &= ~ roundBitsMask;
+	}
+	if ( ( z.low != a.low ) || ( z.high != a.high ) ) {
+		float_exception_flags |= float_flag_inexact;
+	}
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of adding the absolute values of the quadruple-precision
+| floating-point values `a' and `b'.  If `zSign' is 1, the sum is negated
+| before being returned.  `zSign' is ignored if the result is a NaN.
+| The addition is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static float128 addFloat128Sigs( float128 a, float128 b, flag zSign )
+{
+	int32 aExp, bExp, zExp;
+	bits64 aSig0, aSig1, bSig0, bSig1, zSig0, zSig1, zSig2;
+	int32 expDiff;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	bSig1 = extractFloat128Frac1( b );
+	bSig0 = extractFloat128Frac0( b );
+	bExp = extractFloat128Exp( b );
+	expDiff = aExp - bExp;
+	if ( 0 < expDiff ) {
+		if ( aExp == 0x7FFF ) {
+			if ( aSig0 | aSig1 ) return propagateFloat128NaN( a, b );
+			return a;
+		}
+		if ( bExp == 0 ) {
+			--expDiff;
+		}
+		else {
+			bSig0 |= LIT64( 0x0001000000000000 );
+		}
+		shift128ExtraRightJamming(
+			bSig0, bSig1, 0, expDiff, &bSig0, &bSig1, &zSig2 );
+		zExp = aExp;
+	}
+	else if ( expDiff < 0 ) {
+		if ( bExp == 0x7FFF ) {
+			if ( bSig0 | bSig1 ) return propagateFloat128NaN( a, b );
+			return packFloat128( zSign, 0x7FFF, 0, 0 );
+		}
+		if ( aExp == 0 ) {
+			++expDiff;
+		}
+		else {
+			aSig0 |= LIT64( 0x0001000000000000 );
+		}
+		shift128ExtraRightJamming(
+			aSig0, aSig1, 0, - expDiff, &aSig0, &aSig1, &zSig2 );
+		zExp = bExp;
+	}
+	else {
+		if ( aExp == 0x7FFF ) {
+			if ( aSig0 | aSig1 | bSig0 | bSig1 ) {
+				return propagateFloat128NaN( a, b );
+			}
+			return a;
+		}
+		add128( aSig0, aSig1, bSig0, bSig1, &zSig0, &zSig1 );
+		if ( aExp == 0 ) return packFloat128( zSign, 0, zSig0, zSig1 );
+		zSig2 = 0;
+		zSig0 |= LIT64( 0x0002000000000000 );
+		zExp = aExp;
+		goto shiftRight1;
+	}
+	aSig0 |= LIT64( 0x0001000000000000 );
+	add128( aSig0, aSig1, bSig0, bSig1, &zSig0, &zSig1 );
+	--zExp;
+	if ( zSig0 < LIT64( 0x0002000000000000 ) ) goto roundAndPack;
+	++zExp;
+	shiftRight1:
+	shift128ExtraRightJamming(
+		zSig0, zSig1, zSig2, 1, &zSig0, &zSig1, &zSig2 );
+	roundAndPack:
+	return roundAndPackFloat128( zSign, zExp, zSig0, zSig1, zSig2 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of subtracting the absolute values of the quadruple-
+| precision floating-point values `a' and `b'.  If `zSign' is 1, the
+| difference is negated before being returned.  `zSign' is ignored if the
+| result is a NaN.  The subtraction is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static float128 subFloat128Sigs( float128 a, float128 b, flag zSign )
+{
+	int32 aExp, bExp, zExp;
+	bits64 aSig0, aSig1, bSig0, bSig1, zSig0, zSig1;
+	int32 expDiff;
+	float128 z;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	bSig1 = extractFloat128Frac1( b );
+	bSig0 = extractFloat128Frac0( b );
+	bExp = extractFloat128Exp( b );
+	expDiff = aExp - bExp;
+	shortShift128Left( aSig0, aSig1, 14, &aSig0, &aSig1 );
+	shortShift128Left( bSig0, bSig1, 14, &bSig0, &bSig1 );
+	if ( 0 < expDiff ) goto aExpBigger;
+	if ( expDiff < 0 ) goto bExpBigger;
+	if ( aExp == 0x7FFF ) {
+		if ( aSig0 | aSig1 | bSig0 | bSig1 ) {
+			return propagateFloat128NaN( a, b );
+		}
+		float_raise( float_flag_invalid );
+		z.low = float128_default_nan_low;
+		z.high = float128_default_nan_high;
+		return z;
+	}
+	if ( aExp == 0 ) {
+		aExp = 1;
+		bExp = 1;
+	}
+	if ( bSig0 < aSig0 ) goto aBigger;
+	if ( aSig0 < bSig0 ) goto bBigger;
+	if ( bSig1 < aSig1 ) goto aBigger;
+	if ( aSig1 < bSig1 ) goto bBigger;
+	return packFloat128( float_rounding_mode == float_round_down, 0, 0, 0 );
+	bExpBigger:
+	if ( bExp == 0x7FFF ) {
+		if ( bSig0 | bSig1 ) return propagateFloat128NaN( a, b );
+		return packFloat128( zSign ^ 1, 0x7FFF, 0, 0 );
+	}
+	if ( aExp == 0 ) {
+		++expDiff;
+	}
+	else {
+		aSig0 |= LIT64( 0x4000000000000000 );
+	}
+	shift128RightJamming( aSig0, aSig1, - expDiff, &aSig0, &aSig1 );
+	bSig0 |= LIT64( 0x4000000000000000 );
+	bBigger:
+	sub128( bSig0, bSig1, aSig0, aSig1, &zSig0, &zSig1 );
+	zExp = bExp;
+	zSign ^= 1;
+	goto normalizeRoundAndPack;
+	aExpBigger:
+	if ( aExp == 0x7FFF ) {
+		if ( aSig0 | aSig1 ) return propagateFloat128NaN( a, b );
+		return a;
+	}
+	if ( bExp == 0 ) {
+		--expDiff;
+	}
+	else {
+		bSig0 |= LIT64( 0x4000000000000000 );
+	}
+	shift128RightJamming( bSig0, bSig1, expDiff, &bSig0, &bSig1 );
+	aSig0 |= LIT64( 0x4000000000000000 );
+	aBigger:
+	sub128( aSig0, aSig1, bSig0, bSig1, &zSig0, &zSig1 );
+	zExp = aExp;
+	normalizeRoundAndPack:
+	--zExp;
+	return normalizeRoundAndPackFloat128( zSign, zExp - 14, zSig0, zSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of adding the quadruple-precision floating-point values
+| `a' and `b'.  The operation is performed according to the IEC/IEEE Standard
+| for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 float128_add( float128 a, float128 b )
+{
+	flag aSign, bSign;
+
+	aSign = extractFloat128Sign( a );
+	bSign = extractFloat128Sign( b );
+	if ( aSign == bSign ) {
+		return addFloat128Sigs( a, b, aSign );
+	}
+	else {
+		return subFloat128Sigs( a, b, aSign );
+	}
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of subtracting the quadruple-precision floating-point
+| values `a' and `b'.  The operation is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 float128_sub( float128 a, float128 b )
+{
+	flag aSign, bSign;
+
+	aSign = extractFloat128Sign( a );
+	bSign = extractFloat128Sign( b );
+	if ( aSign == bSign ) {
+		return subFloat128Sigs( a, b, aSign );
+	}
+	else {
+		return addFloat128Sigs( a, b, aSign );
+	}
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of multiplying the quadruple-precision floating-point
+| values `a' and `b'.  The operation is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 float128_mul( float128 a, float128 b )
+{
+	flag aSign, bSign, zSign;
+	int32 aExp, bExp, zExp;
+	bits64 aSig0, aSig1, bSig0, bSig1, zSig0, zSig1, zSig2, zSig3;
+	float128 z;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	bSig1 = extractFloat128Frac1( b );
+	bSig0 = extractFloat128Frac0( b );
+	bExp = extractFloat128Exp( b );
+	bSign = extractFloat128Sign( b );
+	zSign = aSign ^ bSign;
+	if ( aExp == 0x7FFF ) {
+		if (    ( aSig0 | aSig1 )
+				|| ( ( bExp == 0x7FFF ) && ( bSig0 | bSig1 ) ) ) {
+			return propagateFloat128NaN( a, b );
+		}
+		if ( ( bExp | bSig0 | bSig1 ) == 0 ) goto invalid;
+		return packFloat128( zSign, 0x7FFF, 0, 0 );
+	}
+	if ( bExp == 0x7FFF ) {
+		if ( bSig0 | bSig1 ) return propagateFloat128NaN( a, b );
+		if ( ( aExp | aSig0 | aSig1 ) == 0 ) {
+	invalid:
+			float_raise( float_flag_invalid );
+			z.low = float128_default_nan_low;
+			z.high = float128_default_nan_high;
+			return z;
+		}
+		return packFloat128( zSign, 0x7FFF, 0, 0 );
+	}
+	if ( aExp == 0 ) {
+		if ( ( aSig0 | aSig1 ) == 0 ) return packFloat128( zSign, 0, 0, 0 );
+		normalizeFloat128Subnormal( aSig0, aSig1, &aExp, &aSig0, &aSig1 );
+	}
+	if ( bExp == 0 ) {
+		if ( ( bSig0 | bSig1 ) == 0 ) return packFloat128( zSign, 0, 0, 0 );
+		normalizeFloat128Subnormal( bSig0, bSig1, &bExp, &bSig0, &bSig1 );
+	}
+	zExp = aExp + bExp - 0x4000;
+	aSig0 |= LIT64( 0x0001000000000000 );
+	shortShift128Left( bSig0, bSig1, 16, &bSig0, &bSig1 );
+	mul128To256( aSig0, aSig1, bSig0, bSig1, &zSig0, &zSig1, &zSig2, &zSig3 );
+	add128( zSig0, zSig1, aSig0, aSig1, &zSig0, &zSig1 );
+	zSig2 |= ( zSig3 != 0 );
+	if ( LIT64( 0x0002000000000000 ) <= zSig0 ) {
+		shift128ExtraRightJamming(
+			zSig0, zSig1, zSig2, 1, &zSig0, &zSig1, &zSig2 );
+		++zExp;
+	}
+	return roundAndPackFloat128( zSign, zExp, zSig0, zSig1, zSig2 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the result of dividing the quadruple-precision floating-point value
+| `a' by the corresponding value `b'.  The operation is performed according to
+| the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 float128_div( float128 a, float128 b )
+{
+	flag aSign, bSign, zSign;
+	int32 aExp, bExp, zExp;
+	bits64 aSig0, aSig1, bSig0, bSig1, zSig0, zSig1, zSig2;
+	bits64 rem0, rem1, rem2, rem3, term0, term1, term2, term3;
+	float128 z;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	bSig1 = extractFloat128Frac1( b );
+	bSig0 = extractFloat128Frac0( b );
+	bExp = extractFloat128Exp( b );
+	bSign = extractFloat128Sign( b );
+	zSign = aSign ^ bSign;
+	if ( aExp == 0x7FFF ) {
+		if ( aSig0 | aSig1 ) return propagateFloat128NaN( a, b );
+		if ( bExp == 0x7FFF ) {
+			if ( bSig0 | bSig1 ) return propagateFloat128NaN( a, b );
+			goto invalid;
+		}
+		return packFloat128( zSign, 0x7FFF, 0, 0 );
+	}
+	if ( bExp == 0x7FFF ) {
+		if ( bSig0 | bSig1 ) return propagateFloat128NaN( a, b );
+		return packFloat128( zSign, 0, 0, 0 );
+	}
+	if ( bExp == 0 ) {
+		if ( ( bSig0 | bSig1 ) == 0 ) {
+			if ( ( aExp | aSig0 | aSig1 ) == 0 ) {
+	invalid:
+				float_raise( float_flag_invalid );
+				z.low = float128_default_nan_low;
+				z.high = float128_default_nan_high;
+				return z;
+			}
+			float_raise( float_flag_divbyzero );
+			return packFloat128( zSign, 0x7FFF, 0, 0 );
+		}
+		normalizeFloat128Subnormal( bSig0, bSig1, &bExp, &bSig0, &bSig1 );
+	}
+	if ( aExp == 0 ) {
+		if ( ( aSig0 | aSig1 ) == 0 ) return packFloat128( zSign, 0, 0, 0 );
+		normalizeFloat128Subnormal( aSig0, aSig1, &aExp, &aSig0, &aSig1 );
+	}
+	zExp = aExp - bExp + 0x3FFD;
+	shortShift128Left(
+		aSig0 | LIT64( 0x0001000000000000 ), aSig1, 15, &aSig0, &aSig1 );
+	shortShift128Left(
+		bSig0 | LIT64( 0x0001000000000000 ), bSig1, 15, &bSig0, &bSig1 );
+	if ( le128( bSig0, bSig1, aSig0, aSig1 ) ) {
+		shift128Right( aSig0, aSig1, 1, &aSig0, &aSig1 );
+		++zExp;
+	}
+	zSig0 = estimateDiv128To64( aSig0, aSig1, bSig0 );
+	mul128By64To192( bSig0, bSig1, zSig0, &term0, &term1, &term2 );
+	sub192( aSig0, aSig1, 0, term0, term1, term2, &rem0, &rem1, &rem2 );
+	while ( (sbits64) rem0 < 0 ) {
+		--zSig0;
+		add192( rem0, rem1, rem2, 0, bSig0, bSig1, &rem0, &rem1, &rem2 );
+	}
+	zSig1 = estimateDiv128To64( rem1, rem2, bSig0 );
+	if ( ( zSig1 & 0x3FFF ) <= 4 ) {
+		mul128By64To192( bSig0, bSig1, zSig1, &term1, &term2, &term3 );
+		sub192( rem1, rem2, 0, term1, term2, term3, &rem1, &rem2, &rem3 );
+		while ( (sbits64) rem1 < 0 ) {
+			--zSig1;
+			add192( rem1, rem2, rem3, 0, bSig0, bSig1, &rem1, &rem2, &rem3 );
+		}
+		zSig1 |= ( ( rem1 | rem2 | rem3 ) != 0 );
+	}
+	shift128ExtraRightJamming( zSig0, zSig1, 0, 15, &zSig0, &zSig1, &zSig2 );
+	return roundAndPackFloat128( zSign, zExp, zSig0, zSig1, zSig2 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the remainder of the quadruple-precision floating-point value `a'
+| with respect to the corresponding value `b'.  The operation is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 float128_rem( float128 a, float128 b )
+{
+	flag aSign, zSign;
+	int32 aExp, bExp, expDiff;
+	bits64 aSig0, aSig1, bSig0, bSig1, q, term0, term1, term2;
+	bits64 allZero, alternateASig0, alternateASig1, sigMean1;
+	sbits64 sigMean0;
+	float128 z;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	bSig1 = extractFloat128Frac1( b );
+	bSig0 = extractFloat128Frac0( b );
+	bExp = extractFloat128Exp( b );
+//    bSign = extractFloat128Sign( b );
+	if ( aExp == 0x7FFF ) {
+		if (    ( aSig0 | aSig1 )
+				|| ( ( bExp == 0x7FFF ) && ( bSig0 | bSig1 ) ) ) {
+			return propagateFloat128NaN( a, b );
+		}
+		goto invalid;
+	}
+	if ( bExp == 0x7FFF ) {
+		if ( bSig0 | bSig1 ) return propagateFloat128NaN( a, b );
+		return a;
+	}
+	if ( bExp == 0 ) {
+		if ( ( bSig0 | bSig1 ) == 0 ) {
+	invalid:
+			float_raise( float_flag_invalid );
+			z.low = float128_default_nan_low;
+			z.high = float128_default_nan_high;
+			return z;
+		}
+		normalizeFloat128Subnormal( bSig0, bSig1, &bExp, &bSig0, &bSig1 );
+	}
+	if ( aExp == 0 ) {
+		if ( ( aSig0 | aSig1 ) == 0 ) return a;
+		normalizeFloat128Subnormal( aSig0, aSig1, &aExp, &aSig0, &aSig1 );
+	}
+	expDiff = aExp - bExp;
+	if ( expDiff < -1 ) return a;
+	shortShift128Left(
+		aSig0 | LIT64( 0x0001000000000000 ),
+		aSig1,
+		15 - ( expDiff < 0 ),
+		&aSig0,
+		&aSig1
+	);
+	shortShift128Left(
+		bSig0 | LIT64( 0x0001000000000000 ), bSig1, 15, &bSig0, &bSig1 );
+	q = le128( bSig0, bSig1, aSig0, aSig1 );
+	if ( q ) sub128( aSig0, aSig1, bSig0, bSig1, &aSig0, &aSig1 );
+	expDiff -= 64;
+	while ( 0 < expDiff ) {
+		q = estimateDiv128To64( aSig0, aSig1, bSig0 );
+		q = ( 4 < q ) ? q - 4 : 0;
+		mul128By64To192( bSig0, bSig1, q, &term0, &term1, &term2 );
+		shortShift192Left( term0, term1, term2, 61, &term1, &term2, &allZero );
+		shortShift128Left( aSig0, aSig1, 61, &aSig0, &allZero );
+		sub128( aSig0, 0, term1, term2, &aSig0, &aSig1 );
+		expDiff -= 61;
+	}
+	if ( -64 < expDiff ) {
+		q = estimateDiv128To64( aSig0, aSig1, bSig0 );
+		q = ( 4 < q ) ? q - 4 : 0;
+		q >>= - expDiff;
+		shift128Right( bSig0, bSig1, 12, &bSig0, &bSig1 );
+		expDiff += 52;
+		if ( expDiff < 0 ) {
+			shift128Right( aSig0, aSig1, - expDiff, &aSig0, &aSig1 );
+		}
+		else {
+			shortShift128Left( aSig0, aSig1, expDiff, &aSig0, &aSig1 );
+		}
+		mul128By64To192( bSig0, bSig1, q, &term0, &term1, &term2 );
+		sub128( aSig0, aSig1, term1, term2, &aSig0, &aSig1 );
+	}
+	else {
+		shift128Right( aSig0, aSig1, 12, &aSig0, &aSig1 );
+		shift128Right( bSig0, bSig1, 12, &bSig0, &bSig1 );
+	}
+	do {
+		alternateASig0 = aSig0;
+		alternateASig1 = aSig1;
+		++q;
+		sub128( aSig0, aSig1, bSig0, bSig1, &aSig0, &aSig1 );
+	} while ( 0 <= (sbits64) aSig0 );
+	add128(
+		aSig0, aSig1, alternateASig0, alternateASig1, (bits64 *)&sigMean0, &sigMean1 );
+	if (    ( sigMean0 < 0 )
+			|| ( ( ( sigMean0 | sigMean1 ) == 0 ) && ( q & 1 ) ) ) {
+		aSig0 = alternateASig0;
+		aSig1 = alternateASig1;
+	}
+	zSign = ( (sbits64) aSig0 < 0 );
+	if ( zSign ) sub128( 0, 0, aSig0, aSig1, &aSig0, &aSig1 );
+	return
+		normalizeRoundAndPackFloat128( aSign ^ zSign, bExp - 4, aSig0, aSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns the square root of the quadruple-precision floating-point value `a'.
+| The operation is performed according to the IEC/IEEE Standard for Binary
+| Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+float128 float128_sqrt( float128 a )
+{
+	flag aSign;
+	int32 aExp, zExp;
+	bits64 aSig0, aSig1, zSig0, zSig1, zSig2, doubleZSig0;
+	bits64 rem0, rem1, rem2, rem3, term0, term1, term2, term3;
+	float128 z;
+
+	aSig1 = extractFloat128Frac1( a );
+	aSig0 = extractFloat128Frac0( a );
+	aExp = extractFloat128Exp( a );
+	aSign = extractFloat128Sign( a );
+	if ( aExp == 0x7FFF ) {
+		if ( aSig0 | aSig1 ) return propagateFloat128NaN( a, a );
+		if ( ! aSign ) return a;
+		goto invalid;
+	}
+	if ( aSign ) {
+		if ( ( aExp | aSig0 | aSig1 ) == 0 ) return a;
+	invalid:
+		float_raise( float_flag_invalid );
+		z.low = float128_default_nan_low;
+		z.high = float128_default_nan_high;
+		return z;
+	}
+	if ( aExp == 0 ) {
+		if ( ( aSig0 | aSig1 ) == 0 ) return packFloat128( 0, 0, 0, 0 );
+		normalizeFloat128Subnormal( aSig0, aSig1, &aExp, &aSig0, &aSig1 );
+	}
+	zExp = ( ( aExp - 0x3FFF )>>1 ) + 0x3FFE;
+	aSig0 |= LIT64( 0x0001000000000000 );
+	zSig0 = estimateSqrt32( aExp, aSig0>>17 );
+	shortShift128Left( aSig0, aSig1, 13 - ( aExp & 1 ), &aSig0, &aSig1 );
+	zSig0 = estimateDiv128To64( aSig0, aSig1, zSig0<<32 ) + ( zSig0<<30 );
+	doubleZSig0 = zSig0<<1;
+	mul64To128( zSig0, zSig0, &term0, &term1 );
+	sub128( aSig0, aSig1, term0, term1, &rem0, &rem1 );
+	while ( (sbits64) rem0 < 0 ) {
+		--zSig0;
+		doubleZSig0 -= 2;
+		add128( rem0, rem1, zSig0>>63, doubleZSig0 | 1, &rem0, &rem1 );
+	}
+	zSig1 = estimateDiv128To64( rem1, 0, doubleZSig0 );
+	if ( ( zSig1 & 0x1FFF ) <= 5 ) {
+		if ( zSig1 == 0 ) zSig1 = 1;
+		mul64To128( doubleZSig0, zSig1, &term1, &term2 );
+		sub128( rem1, 0, term1, term2, &rem1, &rem2 );
+		mul64To128( zSig1, zSig1, &term2, &term3 );
+		sub192( rem1, rem2, 0, 0, term2, term3, &rem1, &rem2, &rem3 );
+		while ( (sbits64) rem1 < 0 ) {
+			--zSig1;
+			shortShift128Left( 0, zSig1, 1, &term2, &term3 );
+			term3 |= 1;
+			term2 |= doubleZSig0;
+			add192( rem1, rem2, rem3, 0, term2, term3, &rem1, &rem2, &rem3 );
+		}
+		zSig1 |= ( ( rem1 | rem2 | rem3 ) != 0 );
+	}
+	shift128ExtraRightJamming( zSig0, zSig1, 0, 14, &zSig0, &zSig1, &zSig2 );
+	return roundAndPackFloat128( 0, zExp, zSig0, zSig1, zSig2 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the quadruple-precision floating-point value `a' is equal to
+| the corresponding value `b', and 0 otherwise.  The comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float128_eq( float128 a, float128 b )
+{
+	if (    (    ( extractFloat128Exp( a ) == 0x7FFF )
+				&& ( extractFloat128Frac0( a ) | extractFloat128Frac1( a ) ) )
+			|| (    ( extractFloat128Exp( b ) == 0x7FFF )
+				&& ( extractFloat128Frac0( b ) | extractFloat128Frac1( b ) ) )
+		) {
+		if (    float128_is_signaling_nan( a )
+				|| float128_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	return
+			( a.low == b.low )
+		&& (    ( a.high == b.high )
+				|| (    ( a.low == 0 )
+					&& ( (bits64) ( ( a.high | b.high )<<1 ) == 0 ) )
+			);
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the quadruple-precision floating-point value `a' is less than
+| or equal to the corresponding value `b', and 0 otherwise.  The comparison
+| is performed according to the IEC/IEEE Standard for Binary Floating-Point
+| Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float128_le( float128 a, float128 b )
+{
+	flag aSign, bSign;
+
+	if (    (    ( extractFloat128Exp( a ) == 0x7FFF )
+				&& ( extractFloat128Frac0( a ) | extractFloat128Frac1( a ) ) )
+			|| (    ( extractFloat128Exp( b ) == 0x7FFF )
+				&& ( extractFloat128Frac0( b ) | extractFloat128Frac1( b ) ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	aSign = extractFloat128Sign( a );
+	bSign = extractFloat128Sign( b );
+	if ( aSign != bSign ) {
+		return
+				aSign
+			|| (    ( ( (bits64) ( ( a.high | b.high )<<1 ) ) | a.low | b.low )
+					== 0 );
+	}
+	return
+			aSign ? le128( b.high, b.low, a.high, a.low )
+		: le128( a.high, a.low, b.high, b.low );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the quadruple-precision floating-point value `a' is less than
+| the corresponding value `b', and 0 otherwise.  The comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float128_lt( float128 a, float128 b )
+{
+	flag aSign, bSign;
+
+	if (    (    ( extractFloat128Exp( a ) == 0x7FFF )
+				&& ( extractFloat128Frac0( a ) | extractFloat128Frac1( a ) ) )
+			|| (    ( extractFloat128Exp( b ) == 0x7FFF )
+				&& ( extractFloat128Frac0( b ) | extractFloat128Frac1( b ) ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	aSign = extractFloat128Sign( a );
+	bSign = extractFloat128Sign( b );
+	if ( aSign != bSign ) {
+		return
+				aSign
+			&& (    ( ( (bits64) ( ( a.high | b.high )<<1 ) ) | a.low | b.low )
+					!= 0 );
+	}
+	return
+			aSign ? lt128( b.high, b.low, a.high, a.low )
+		: lt128( a.high, a.low, b.high, b.low );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the quadruple-precision floating-point value `a' is equal to
+| the corresponding value `b', and 0 otherwise.  The invalid exception is
+| raised if either operand is a NaN.  Otherwise, the comparison is performed
+| according to the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float128_eq_signaling( float128 a, float128 b )
+{
+	if (    (    ( extractFloat128Exp( a ) == 0x7FFF )
+				&& ( extractFloat128Frac0( a ) | extractFloat128Frac1( a ) ) )
+			|| (    ( extractFloat128Exp( b ) == 0x7FFF )
+				&& ( extractFloat128Frac0( b ) | extractFloat128Frac1( b ) ) )
+		) {
+		float_raise( float_flag_invalid );
+		return 0;
+	}
+	return
+			( a.low == b.low )
+		&& (    ( a.high == b.high )
+				|| (    ( a.low == 0 )
+					&& ( (bits64) ( ( a.high | b.high )<<1 ) == 0 ) )
+			);
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the quadruple-precision floating-point value `a' is less than
+| or equal to the corresponding value `b', and 0 otherwise.  Quiet NaNs do not
+| cause an exception.  Otherwise, the comparison is performed according to the
+| IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float128_le_quiet( float128 a, float128 b )
+{
+	flag aSign, bSign;
+
+	if (    (    ( extractFloat128Exp( a ) == 0x7FFF )
+				&& ( extractFloat128Frac0( a ) | extractFloat128Frac1( a ) ) )
+			|| (    ( extractFloat128Exp( b ) == 0x7FFF )
+				&& ( extractFloat128Frac0( b ) | extractFloat128Frac1( b ) ) )
+		) {
+		if (    float128_is_signaling_nan( a )
+				|| float128_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	aSign = extractFloat128Sign( a );
+	bSign = extractFloat128Sign( b );
+	if ( aSign != bSign ) {
+		return
+				aSign
+			|| (    ( ( (bits64) ( ( a.high | b.high )<<1 ) ) | a.low | b.low )
+					== 0 );
+	}
+	return
+			aSign ? le128( b.high, b.low, a.high, a.low )
+		: le128( a.high, a.low, b.high, b.low );
+
+}
+
+/*----------------------------------------------------------------------------
+| Returns 1 if the quadruple-precision floating-point value `a' is less than
+| the corresponding value `b', and 0 otherwise.  Quiet NaNs do not cause an
+| exception.  Otherwise, the comparison is performed according to the IEC/IEEE
+| Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+flag float128_lt_quiet( float128 a, float128 b )
+{
+	flag aSign, bSign;
+
+	if (    (    ( extractFloat128Exp( a ) == 0x7FFF )
+				&& ( extractFloat128Frac0( a ) | extractFloat128Frac1( a ) ) )
+			|| (    ( extractFloat128Exp( b ) == 0x7FFF )
+				&& ( extractFloat128Frac0( b ) | extractFloat128Frac1( b ) ) )
+		) {
+		if (    float128_is_signaling_nan( a )
+				|| float128_is_signaling_nan( b ) ) {
+			float_raise( float_flag_invalid );
+		}
+		return 0;
+	}
+	aSign = extractFloat128Sign( a );
+	bSign = extractFloat128Sign( b );
+	if ( aSign != bSign ) {
+		return
+				aSign
+			&& (    ( ( (bits64) ( ( a.high | b.high )<<1 ) ) | a.low | b.low )
+					!= 0 );
+	}
+	return
+			aSign ? lt128( b.high, b.low, a.high, a.low )
+		: lt128( a.high, a.low, b.high, b.low );
+
+}
+
+#endif

--- a/softfloat/softfloat.h
+++ b/softfloat/softfloat.h
@@ -1,0 +1,460 @@
+
+/*============================================================================
+
+This C header file is part of the SoftFloat IEC/IEEE Floating-point Arithmetic
+Package, Release 2b.
+
+Written by John R. Hauser.  This work was made possible in part by the
+International Computer Science Institute, located at Suite 600, 1947 Center
+Street, Berkeley, California 94704.  Funding was partially provided by the
+National Science Foundation under grant MIP-9311980.  The original version
+of this code was written as part of a project to build a fixed-point vector
+processor in collaboration with the University of California at Berkeley,
+overseen by Profs. Nelson Morgan and John Wawrzynek.  More information
+is available through the Web page `http://www.cs.berkeley.edu/~jhauser/
+arithmetic/SoftFloat.html'.
+
+THIS SOFTWARE IS DISTRIBUTED AS IS, FOR FREE.  Although reasonable effort has
+been made to avoid it, THIS SOFTWARE MAY CONTAIN FAULTS THAT WILL AT TIMES
+RESULT IN INCORRECT BEHAVIOR.  USE OF THIS SOFTWARE IS RESTRICTED TO PERSONS
+AND ORGANIZATIONS WHO CAN AND WILL TAKE FULL RESPONSIBILITY FOR ALL LOSSES,
+COSTS, OR OTHER PROBLEMS THEY INCUR DUE TO THE SOFTWARE, AND WHO FURTHERMORE
+EFFECTIVELY INDEMNIFY JOHN HAUSER AND THE INTERNATIONAL COMPUTER SCIENCE
+INSTITUTE (possibly via similar legal warning) AGAINST ALL LOSSES, COSTS, OR
+OTHER PROBLEMS INCURRED BY THEIR CUSTOMERS AND CLIENTS DUE TO THE SOFTWARE.
+
+Derivative works are acceptable, even for commercial purposes, so long as
+(1) the source code for the derivative work includes prominent notice that
+the work is derivative, and (2) the source code includes prominent notice with
+these four paragraphs for those parts of this code that are retained.
+
+=============================================================================*/
+
+/*----------------------------------------------------------------------------
+| The macro `FLOATX80' must be defined to enable the extended double-precision
+| floating-point format `floatx80'.  If this macro is not defined, the
+| `floatx80' type will not be defined, and none of the functions that either
+| input or output the `floatx80' type will be defined.  The same applies to
+| the `FLOAT128' macro and the quadruple-precision format `float128'.
+*----------------------------------------------------------------------------*/
+#define FLOATX80
+#define FLOAT128
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE floating-point types.
+*----------------------------------------------------------------------------*/
+typedef bits32 float32;
+typedef bits64 float64;
+#ifdef FLOATX80
+typedef struct {
+	bits16 high;
+	bits64 low;
+} floatx80;
+#endif
+#ifdef FLOAT128
+typedef struct {
+	bits64 high, low;
+} float128;
+#endif
+
+/*----------------------------------------------------------------------------
+| Primitive arithmetic functions, including multi-word arithmetic, and
+| division and square root approximations.  (Can be specialized to target if
+| desired.)
+*----------------------------------------------------------------------------*/
+#include "softfloat-macros"
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE floating-point underflow tininess-detection mode.
+*----------------------------------------------------------------------------*/
+extern int8 float_detect_tininess;
+enum {
+	float_tininess_after_rounding  = 0,
+	float_tininess_before_rounding = 1
+};
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE floating-point rounding mode.
+*----------------------------------------------------------------------------*/
+extern int8 float_rounding_mode;
+enum {
+	float_round_nearest_even = 0,
+	float_round_to_zero      = 1,
+	float_round_down         = 2,
+	float_round_up           = 3
+};
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE floating-point exception flags.
+*----------------------------------------------------------------------------*/
+extern int8 float_exception_flags;
+enum {
+	float_flag_invalid = 0x01, float_flag_denormal = 0x02, float_flag_divbyzero = 0x04, float_flag_overflow = 0x08,
+	float_flag_underflow = 0x10, float_flag_inexact = 0x20
+};
+
+/*----------------------------------------------------------------------------
+| Routine to raise any or all of the software IEC/IEEE floating-point
+| exception flags.
+*----------------------------------------------------------------------------*/
+void float_raise( int8 );
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE integer-to-floating-point conversion routines.
+*----------------------------------------------------------------------------*/
+float32 int32_to_float32( int32 );
+float64 int32_to_float64( int32 );
+#ifdef FLOATX80
+floatx80 int32_to_floatx80( int32 );
+#endif
+#ifdef FLOAT128
+float128 int32_to_float128( int32 );
+#endif
+float32 int64_to_float32( int64 );
+float64 int64_to_float64( int64 );
+#ifdef FLOATX80
+floatx80 int64_to_floatx80( int64 );
+#endif
+#ifdef FLOAT128
+float128 int64_to_float128( int64 );
+#endif
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE single-precision conversion routines.
+*----------------------------------------------------------------------------*/
+int32 float32_to_int32( float32 );
+int32 float32_to_int32_round_to_zero( float32 );
+int64 float32_to_int64( float32 );
+int64 float32_to_int64_round_to_zero( float32 );
+float64 float32_to_float64( float32 );
+#ifdef FLOATX80
+floatx80 float32_to_floatx80( float32 );
+#endif
+#ifdef FLOAT128
+float128 float32_to_float128( float32 );
+#endif
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE single-precision operations.
+*----------------------------------------------------------------------------*/
+float32 float32_round_to_int( float32 );
+float32 float32_add( float32, float32 );
+float32 float32_sub( float32, float32 );
+float32 float32_mul( float32, float32 );
+float32 float32_div( float32, float32 );
+float32 float32_rem( float32, float32 );
+float32 float32_sqrt( float32 );
+flag float32_eq( float32, float32 );
+flag float32_le( float32, float32 );
+flag float32_lt( float32, float32 );
+flag float32_eq_signaling( float32, float32 );
+flag float32_le_quiet( float32, float32 );
+flag float32_lt_quiet( float32, float32 );
+flag float32_is_signaling_nan( float32 );
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE double-precision conversion routines.
+*----------------------------------------------------------------------------*/
+int32 float64_to_int32( float64 );
+int32 float64_to_int32_round_to_zero( float64 );
+int64 float64_to_int64( float64 );
+int64 float64_to_int64_round_to_zero( float64 );
+float32 float64_to_float32( float64 );
+#ifdef FLOATX80
+floatx80 float64_to_floatx80( float64 );
+#endif
+#ifdef FLOAT128
+float128 float64_to_float128( float64 );
+#endif
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE double-precision operations.
+*----------------------------------------------------------------------------*/
+float64 float64_round_to_int( float64 );
+float64 float64_add( float64, float64 );
+float64 float64_sub( float64, float64 );
+float64 float64_mul( float64, float64 );
+float64 float64_div( float64, float64 );
+float64 float64_rem( float64, float64 );
+float64 float64_sqrt( float64 );
+flag float64_eq( float64, float64 );
+flag float64_le( float64, float64 );
+flag float64_lt( float64, float64 );
+flag float64_eq_signaling( float64, float64 );
+flag float64_le_quiet( float64, float64 );
+flag float64_lt_quiet( float64, float64 );
+flag float64_is_signaling_nan( float64 );
+
+#ifdef FLOATX80
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE extended double-precision conversion routines.
+*----------------------------------------------------------------------------*/
+int32 floatx80_to_int32( floatx80 );
+int32 floatx80_to_int32_round_to_zero( floatx80 );
+int64 floatx80_to_int64( floatx80 );
+int64 floatx80_to_int64_round_to_zero( floatx80 );
+float32 floatx80_to_float32( floatx80 );
+float64 floatx80_to_float64( floatx80 );
+#ifdef FLOAT128
+float128 floatx80_to_float128( floatx80 );
+#endif
+floatx80 floatx80_scale(floatx80 a, floatx80 b);
+
+/*----------------------------------------------------------------------------
+| Packs the sign `zSign', exponent `zExp', and significand `zSig' into an
+| extended double-precision floating-point value, returning the result.
+*----------------------------------------------------------------------------*/
+
+static inline floatx80 packFloatx80( flag zSign, int32 zExp, bits64 zSig )
+{
+	floatx80 z;
+
+	z.low = zSig;
+	z.high = ( ( (bits16) zSign )<<15 ) + zExp;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE extended double-precision rounding precision.  Valid
+| values are 32, 64, and 80.
+*----------------------------------------------------------------------------*/
+extern int8 floatx80_rounding_precision;
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE extended double-precision operations.
+*----------------------------------------------------------------------------*/
+floatx80 floatx80_round_to_int( floatx80 );
+floatx80 floatx80_add( floatx80, floatx80 );
+floatx80 floatx80_sub( floatx80, floatx80 );
+floatx80 floatx80_mul( floatx80, floatx80 );
+floatx80 floatx80_div( floatx80, floatx80 );
+floatx80 floatx80_rem( floatx80, floatx80 );
+floatx80 floatx80_sqrt( floatx80 );
+flag floatx80_eq( floatx80, floatx80 );
+flag floatx80_le( floatx80, floatx80 );
+flag floatx80_lt( floatx80, floatx80 );
+flag floatx80_eq_signaling( floatx80, floatx80 );
+flag floatx80_le_quiet( floatx80, floatx80 );
+flag floatx80_lt_quiet( floatx80, floatx80 );
+flag floatx80_is_signaling_nan( floatx80 );
+
+/* int floatx80_fsin(floatx80 &a);
+int floatx80_fcos(floatx80 &a);
+int floatx80_ftan(floatx80 &a); */
+
+floatx80 floatx80_flognp1(floatx80 a);
+floatx80 floatx80_flogn(floatx80 a);
+floatx80 floatx80_flog2(floatx80 a);
+floatx80 floatx80_flog10(floatx80 a);
+
+// roundAndPackFloatx80 used to be in softfloat-round-pack, is now in softfloat.c
+floatx80 roundAndPackFloatx80(int8 roundingPrecision, flag zSign, int32 zExp, bits64 zSig0, bits64 zSig1);
+
+#endif
+
+#ifdef FLOAT128
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE quadruple-precision conversion routines.
+*----------------------------------------------------------------------------*/
+int32 float128_to_int32( float128 );
+int32 float128_to_int32_round_to_zero( float128 );
+int64 float128_to_int64( float128 );
+int64 float128_to_int64_round_to_zero( float128 );
+float32 float128_to_float32( float128 );
+float64 float128_to_float64( float128 );
+#ifdef FLOATX80
+floatx80 float128_to_floatx80( float128 );
+#endif
+
+/*----------------------------------------------------------------------------
+| Software IEC/IEEE quadruple-precision operations.
+*----------------------------------------------------------------------------*/
+float128 float128_round_to_int( float128 );
+float128 float128_add( float128, float128 );
+float128 float128_sub( float128, float128 );
+float128 float128_mul( float128, float128 );
+float128 float128_div( float128, float128 );
+float128 float128_rem( float128, float128 );
+float128 float128_sqrt( float128 );
+flag float128_eq( float128, float128 );
+flag float128_le( float128, float128 );
+flag float128_lt( float128, float128 );
+flag float128_eq_signaling( float128, float128 );
+flag float128_le_quiet( float128, float128 );
+flag float128_lt_quiet( float128, float128 );
+flag float128_is_signaling_nan( float128 );
+
+/*----------------------------------------------------------------------------
+| Packs the sign `zSign', the exponent `zExp', and the significand formed
+| by the concatenation of `zSig0' and `zSig1' into a quadruple-precision
+| floating-point value, returning the result.  After being shifted into the
+| proper positions, the three fields `zSign', `zExp', and `zSig0' are simply
+| added together to form the most significant 32 bits of the result.  This
+| means that any integer portion of `zSig0' will be added into the exponent.
+| Since a properly normalized significand will have an integer portion equal
+| to 1, the `zExp' input should be 1 less than the desired result exponent
+| whenever `zSig0' and `zSig1' concatenated form a complete, normalized
+| significand.
+*----------------------------------------------------------------------------*/
+
+static inline float128
+	packFloat128( flag zSign, int32 zExp, bits64 zSig0, bits64 zSig1 )
+{
+	float128 z;
+
+	z.low = zSig1;
+	z.high = ( ( (bits64) zSign )<<63 ) + ( ( (bits64) zExp )<<48 ) + zSig0;
+	return z;
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes an abstract floating-point value having sign `zSign', exponent `zExp',
+| and extended significand formed by the concatenation of `zSig0', `zSig1',
+| and `zSig2', and returns the proper quadruple-precision floating-point value
+| corresponding to the abstract input.  Ordinarily, the abstract value is
+| simply rounded and packed into the quadruple-precision format, with the
+| inexact exception raised if the abstract input cannot be represented
+| exactly.  However, if the abstract value is too large, the overflow and
+| inexact exceptions are raised and an infinity or maximal finite value is
+| returned.  If the abstract value is too small, the input value is rounded to
+| a subnormal number, and the underflow and inexact exceptions are raised if
+| the abstract input cannot be represented exactly as a subnormal quadruple-
+| precision floating-point number.
+|     The input significand must be normalized or smaller.  If the input
+| significand is not normalized, `zExp' must be 0; in that case, the result
+| returned is a subnormal number, and it must not require rounding.  In the
+| usual case that the input significand is normalized, `zExp' must be 1 less
+| than the ``true'' floating-point exponent.  The handling of underflow and
+| overflow follows the IEC/IEEE Standard for Binary Floating-Point Arithmetic.
+*----------------------------------------------------------------------------*/
+
+static inline float128
+	roundAndPackFloat128(
+		flag zSign, int32 zExp, bits64 zSig0, bits64 zSig1, bits64 zSig2 )
+{
+	int8 roundingMode;
+	flag roundNearestEven, increment, isTiny;
+
+	roundingMode = float_rounding_mode;
+	roundNearestEven = ( roundingMode == float_round_nearest_even );
+	increment = ( (sbits64) zSig2 < 0 );
+	if ( ! roundNearestEven ) {
+		if ( roundingMode == float_round_to_zero ) {
+			increment = 0;
+		}
+		else {
+			if ( zSign ) {
+				increment = ( roundingMode == float_round_down ) && zSig2;
+			}
+			else {
+				increment = ( roundingMode == float_round_up ) && zSig2;
+			}
+		}
+	}
+	if ( 0x7FFD <= (bits32) zExp ) {
+		if (    ( 0x7FFD < zExp )
+				|| (    ( zExp == 0x7FFD )
+					&& eq128(
+							LIT64( 0x0001FFFFFFFFFFFF ),
+							LIT64( 0xFFFFFFFFFFFFFFFF ),
+							zSig0,
+							zSig1
+						)
+					&& increment
+				)
+			) {
+			float_raise( float_flag_overflow | float_flag_inexact );
+			if (    ( roundingMode == float_round_to_zero )
+					|| ( zSign && ( roundingMode == float_round_up ) )
+					|| ( ! zSign && ( roundingMode == float_round_down ) )
+				) {
+				return
+					packFloat128(
+						zSign,
+						0x7FFE,
+						LIT64( 0x0000FFFFFFFFFFFF ),
+						LIT64( 0xFFFFFFFFFFFFFFFF )
+					);
+			}
+			return packFloat128( zSign, 0x7FFF, 0, 0 );
+		}
+		if ( zExp < 0 ) {
+			isTiny =
+					( float_detect_tininess == float_tininess_before_rounding )
+				|| ( zExp < -1 )
+				|| ! increment
+				|| lt128(
+						zSig0,
+						zSig1,
+						LIT64( 0x0001FFFFFFFFFFFF ),
+						LIT64( 0xFFFFFFFFFFFFFFFF )
+					);
+			shift128ExtraRightJamming(
+				zSig0, zSig1, zSig2, - zExp, &zSig0, &zSig1, &zSig2 );
+			zExp = 0;
+			if ( isTiny && zSig2 ) float_raise( float_flag_underflow );
+			if ( roundNearestEven ) {
+				increment = ( (sbits64) zSig2 < 0 );
+			}
+			else {
+				if ( zSign ) {
+					increment = ( roundingMode == float_round_down ) && zSig2;
+				}
+				else {
+					increment = ( roundingMode == float_round_up ) && zSig2;
+				}
+			}
+		}
+	}
+	if ( zSig2 ) float_exception_flags |= float_flag_inexact;
+	if ( increment ) {
+		add128( zSig0, zSig1, 0, 1, &zSig0, &zSig1 );
+		zSig1 &= ~ ( ( zSig2 + zSig2 == 0 ) & roundNearestEven );
+	}
+	else {
+		if ( ( zSig0 | zSig1 ) == 0 ) zExp = 0;
+	}
+	return packFloat128( zSign, zExp, zSig0, zSig1 );
+
+}
+
+/*----------------------------------------------------------------------------
+| Takes an abstract floating-point value having sign `zSign', exponent `zExp',
+| and significand formed by the concatenation of `zSig0' and `zSig1', and
+| returns the proper quadruple-precision floating-point value corresponding
+| to the abstract input.  This routine is just like `roundAndPackFloat128'
+| except that the input significand has fewer bits and does not have to be
+| normalized.  In all cases, `zExp' must be 1 less than the ``true'' floating-
+| point exponent.
+*----------------------------------------------------------------------------*/
+
+static inline float128
+	normalizeRoundAndPackFloat128(
+		flag zSign, int32 zExp, bits64 zSig0, bits64 zSig1 )
+{
+	int8 shiftCount;
+	bits64 zSig2;
+
+	if ( zSig0 == 0 ) {
+		zSig0 = zSig1;
+		zSig1 = 0;
+		zExp -= 64;
+	}
+	shiftCount = countLeadingZeros64( zSig0 ) - 15;
+	if ( 0 <= shiftCount ) {
+		zSig2 = 0;
+		shortShift128Left( zSig0, zSig1, shiftCount, &zSig0, &zSig1 );
+	}
+	else {
+		shift128ExtraRightJamming(
+			zSig0, zSig1, 0, - shiftCount, &zSig0, &zSig1, &zSig2 );
+	}
+	zExp -= shiftCount;
+	return roundAndPackFloat128( zSign, zExp, zSig0, zSig1, zSig2 );
+
+}
+#endif


### PR DESCRIPTION
the biggest part here is the usage of softfloat, from a lib found on the web.
But it's better to use the mame version because the one from the web has 1 makefile + some headers / target platform, + the latest version has a ton of files, here this version is much smaller and compiles assuming you just change the basic types in softload/mamesf.h (I changed the file to use the current basic types from musashi).
I changed the define for the basic types to typedef but it was useless after all, I can revert to the old defines if you prefer but softfloat is using typedefs anyway so you need a compiler supporting that.

The softfloat lib allows to have some support for the special formats which were not supported before, the surprise is that it seems as fast as before, it's less readable though but I guess you get used to it...

mame has added some prototype functions using the c++ & as parameter in softfloat.h, which makes an error with gcc, you need g++ for that, so I just commented them out for now, they are not used for now here, probably later (it's about fsin, fcos and ftan).
That should be all, I think I'll take another break after that !