### PR TITLE
Minor fixes to keep modern compilers happy

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -283,7 +283,7 @@ M68KMAKE_OPCODE_HANDLER_HEADER
 #include "m68kcpu.h"
 extern void m68040_fpu_op0(void);
 extern void m68040_fpu_op1(void);
-extern void m68881_mmu_ops();
+extern void m68881_mmu_ops(void);
 
 /* ======================================================================== */
 /* ========================= INSTRUCTION HANDLERS ========================= */

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -40,7 +40,7 @@
 
 extern void m68040_fpu_op0(void);
 extern void m68040_fpu_op1(void);
-extern void m68881_mmu_ops();
+extern void m68881_mmu_ops(void);
 extern unsigned char m68ki_cycles[][0x10000];
 extern void (*m68ki_instruction_jump_table[0x10000])(void); /* opcode handler jump table */
 extern void m68ki_build_opcode_table(void);

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -66,12 +66,14 @@ const char *const m68ki_cpu_names[] =
 	"Invalid CPU",
 	"M68000",
 	"M68010",
-	"Invalid CPU",
-	"M68EC020"
-	"Invalid CPU",
-	"Invalid CPU",
-	"Invalid CPU",
-	"M68020"
+	"M68EC020",
+	"M68020",
+	"M68EC030",
+	"M68030",
+	"M68EC040",
+	"M68LC040",
+	"M68040",
+	"SCC68070",
 };
 #endif /* M68K_LOG_ENABLE */
 

--- a/m68kdasm.c
+++ b/m68kdasm.c
@@ -239,7 +239,7 @@ static const char *const g_cpcc[64] =
 {/* 000    001    010    011    100    101    110    111 */
 	  "f",  "eq", "ogt", "oge", "olt", "ole", "ogl",  "or", /* 000 */
 	 "un", "ueq", "ugt", "uge", "ult", "ule",  "ne",   "t", /* 001 */
-	 "sf", "seq",  "gt",  "ge",  "lt",  "le",  "gl"  "gle", /* 010 */
+	 "sf", "seq",  "gt",  "ge",  "lt",  "le",  "gl",  "gle", /* 010 */
   "ngle", "ngl", "nle", "nlt", "nge", "ngt", "sne",  "st", /* 011 */
 	  "?",   "?",   "?",   "?",   "?",   "?",   "?",   "?", /* 100 */
 	  "?",   "?",   "?",   "?",   "?",   "?",   "?",   "?", /* 101 */

--- a/m68kfpu.c
+++ b/m68kfpu.c
@@ -4,7 +4,7 @@
 
 extern void exit(int);
 
-static void fatalerror(char *format, ...) {
+static void fatalerror(const char *format, ...) {
       va_list ap;
       va_start(ap,format);
       vfprintf(stderr,format,ap);  // JFF: fixed. Was using fprintf and arguments were wrong

--- a/m68kmake.c
+++ b/m68kmake.c
@@ -218,8 +218,8 @@ typedef struct
 
 
 /* Function Prototypes */
-void error_exit(char* fmt, ...);
-void perror_exit(char* fmt, ...);
+void error_exit(const char* fmt, ...);
+void perror_exit(const char* fmt, ...);
 int check_strsncpy(char* dst, char* src, int maxlength);
 int check_atoi(char* str, int *result);
 int skip_spaces(char* str);
@@ -469,7 +469,7 @@ const int g_clr_cycle_table[13][3] =
 /* ======================================================================== */
 
 /* Print an error message and exit with status error */
-void error_exit(char* fmt, ...)
+void error_exit(const char* fmt, ...)
 {
 	va_list args;
 	fprintf(stderr, "In %s, near or on line %d:\n\t", g_input_filename, g_line_number);
@@ -486,7 +486,7 @@ void error_exit(char* fmt, ...)
 }
 
 /* Print an error message, call perror(), and exit with status error */
-void perror_exit(char* fmt, ...)
+void perror_exit(const char* fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);

--- a/m68kmmu.h
+++ b/m68kmmu.h
@@ -177,7 +177,7 @@ uint pmmu_translate_addr(uint addr_in)
 
 */
 
-void m68881_mmu_ops()
+void m68881_mmu_ops(void)
 {
 	uint16 modes;
 	uint32 ea = m68ki_cpu.ir & 0x3f;

--- a/softfloat/softfloat-specialize
+++ b/softfloat/softfloat-specialize
@@ -30,6 +30,12 @@ these four paragraphs for those parts of this code that are retained.
 
 =============================================================================*/
 
+flag float32_is_nan( float32 a );
+flag float64_is_nan( float64 a );
+flag floatx80_is_nan( floatx80 a );
+floatx80 propagateFloatx80NaN( floatx80 a, floatx80 b );
+flag float128_is_nan( float128 a );
+
 /*----------------------------------------------------------------------------
 | Underflow tininess-detection mode, statically initialized to default value.
 | (The declaration in `softfloat.h' must match the `int8' type here.)


### PR DESCRIPTION
The first two commits are strictly speaking bugfixes, where constant strings were concatenated due to missing commas.

The other three are just polish.