### PR TITLE
fixed BFINS instruction when width+offset > 32

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -2950,7 +2950,8 @@ M68KMAKE_OP(bfins, 32, ., .)
 		if((width + offset) > 32)
 		{
 			mask_byte = MASK_OUT_ABOVE_8(mask_base);
-			insert_byte = MASK_OUT_ABOVE_8(insert_base);
+
+			insert_byte = MASK_OUT_ABOVE_8(insert_base << (8 - (offset & 7)));  // JFF: else offset isn't taken into account
 			data_byte = m68ki_read_8(ea+4);
 			FLAG_Z |= (data_byte & mask_byte);
 			m68ki_write_8(ea+4, (data_byte & ~mask_byte) | insert_byte);


### PR DESCRIPTION
This is a corner case of BFINS instruction when width + offset > 32 (width = 0 makes it 32 too)

To test :


D0 = $275

A0 = some address

BFINS D0,(a0){4:0}  => A0 holds: X0000027, A0+4 holds: 5XXXXXXX


Without the correction, second longword is incorrect because shifting isn’t taken into account and we get

A0 holds: X0000027, A0+4 holds: 75XXXXXX


UAE core does that shifting, musashi did not. Relevant uae code:

       if (((offset & 7) + width) > 32) {

            bf1 = (bf1 & (0xff >> (width - 32 + (offset & 7)))) |

            (tmp << (8 - (offset & 7)));  <-- here the shifting with offset is performed

            put_byte(dsta+4,bf1);

We had this issue in our application and that changed fixed functionnal behaviour

BFTST and BFSET and BFCLR instructions probably have the same issue, but we're not using them in our application with a width > 32 so we didn't took the time to work on a fix.