### PR TITLE
Silence uninitialized variable warnings

### DIFF
--- a/m68kfpu.c
+++ b/m68kfpu.c
@@ -596,7 +596,7 @@ static uint64 READ_EA_64(int ea)
 
 static floatx80 READ_EA_FPE(int mode, int reg, uint32 di_mode_ea)
 {
-	floatx80 fpr;
+	floatx80 fpr = {0, 0};
 
 	switch (mode)
 	{
@@ -659,7 +659,7 @@ static floatx80 READ_EA_FPE(int mode, int reg, uint32 di_mode_ea)
 
 static floatx80 READ_EA_PACK(int ea)
 {
-	floatx80 fpr;
+	floatx80 fpr = {0, 0};
 	int mode = (ea >> 3) & 0x7;
 	int reg = (ea & 0x7);
 
@@ -1052,7 +1052,7 @@ static void fpgen_rm_reg(uint16 w2)
 	int src = (w2 >> 10) & 0x7;
 	int dst = (w2 >>  7) & 0x7;
 	int opmode = w2 & 0x7f;
-	floatx80 source;
+	floatx80 source = {0, 0};
 
 	// fmovecr #$f, fp0	f200 5c0f
 


### PR DESCRIPTION
In certain cases, `floatx80` variables were left uninitialized before
fatal errors. In practice this really didn't matter because those
variables were never used again before calling `exit`, but it did lead
to clang compiler warnings. This change initializes the variables to
keep the compiler happy.