### PR TITLE
Update sim.c

### DIFF
--- a/example/sim.c
+++ b/example/sim.c
@@ -373,7 +373,7 @@ void output_device_reset(void)
 
 void output_device_update(void)
 {
-	if(!g_output_device_ready)
+	if(g_output_device_ready)
 	{
 		if((time(NULL) - g_output_device_last_output) >= OUTPUT_DEVICE_PERIOD)
 		{


### PR DESCRIPTION
This fixes the weird double output on the console (at least on linux). Seems you want to execute the code inside the if () only if device is ready, not when it isn't.