### PR TITLE
reported cycle count is bogus

### DIFF
--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -1006,7 +1006,11 @@ int m68k_execute(int num_cycles)
 		SET_CYCLES(0);
 
 	/* return how many clocks we used */
-	return m68ki_initial_cycles - GET_CYCLES();
+	if (num_cycles == m68ki_initial_cycles)
+		return m68ki_initial_cycles - GET_CYCLES();
+
+	/* modified by end_timeslice. */
+	return num_cycles - m68ki_initial_cycles;
 }
 
 


### PR DESCRIPTION
The reported cycle count is bogus. You can detect this by running a simple loop with different loop count: the cycle count does not increase steadily, it's more like an increasing sawtooth.

IMOH the computation/counting should be fixed, but it was easier to patch the return value to remove the sawtooth.