### PR TITLE
Correct cycle count returned by m68k_execute

### DIFF
--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -1006,11 +1006,7 @@ int m68k_execute(int num_cycles)
 		SET_CYCLES(0);
 
 	/* return how many clocks we used */
-	if (num_cycles == m68ki_initial_cycles)
-		return m68ki_initial_cycles - GET_CYCLES();
-
-	/* modified by end_timeslice. */
-	return num_cycles - m68ki_initial_cycles;
+	return m68ki_initial_cycles - GET_CYCLES();
 }
 
 
@@ -1034,7 +1030,7 @@ void m68k_modify_timeslice(int cycles)
 
 void m68k_end_timeslice(void)
 {
-	m68ki_initial_cycles = GET_CYCLES();
+	m68ki_initial_cycles -= GET_CYCLES();
 	SET_CYCLES(0);
 }
 


### PR DESCRIPTION
Number of cycles reported by m68k_execute() was incorrect if  m68k_modify_timeslice() was used.

This bug was introduced by the last change done to fix the cycle count if m68k_end_timeslice() was used.

Value return is now correct if m68k_end_timeslice() or m68k_modify_timeslice() is used.