### PR TITLE
Prefix most of the preprocessor macros with `M68K_`

### DIFF
--- a/example/m68kconf.h
+++ b/example/m68kconf.h
@@ -34,14 +34,14 @@
 
 
 /* Configuration switches.
- * Use OPT_SPECIFY_HANDLER for configuration options that allow callbacks.
- * OPT_SPECIFY_HANDLER causes the core to link directly to the function
+ * Use M68K_OPT_SPECIFY_HANDLER for configuration options that allow callbacks.
+ * M68K_OPT_SPECIFY_HANDLER causes the core to link directly to the function
  * or macro you specify, rather than using callback functions whose pointer
  * must be passed in using m68k_set_xxx_callback().
  */
-#define OPT_OFF             0
-#define OPT_ON              1
-#define OPT_SPECIFY_HANDLER 2
+#define M68K_OPT_OFF             0
+#define M68K_OPT_ON              1
+#define M68K_OPT_SPECIFY_HANDLER 2
 
 
 /* ======================================================================== */
@@ -49,14 +49,14 @@
 /* ======================================================================== */
 
 /* If you're compiling this for MAME, only change M68K_COMPILE_FOR_MAME
- * to OPT_ON and use m68kmame.h to configure the 68k core.
+ * to M68K_OPT_ON and use m68kmame.h to configure the 68k core.
  */
 #ifndef M68K_COMPILE_FOR_MAME
-#define M68K_COMPILE_FOR_MAME      OPT_OFF
+#define M68K_COMPILE_FOR_MAME      M68K_OPT_OFF
 #endif /* M68K_COMPILE_FOR_MAME */
 
 
-#if M68K_COMPILE_FOR_MAME == OPT_OFF
+#if M68K_COMPILE_FOR_MAME == M68K_OPT_OFF
 
 
 /* ======================================================================== */
@@ -64,69 +64,69 @@
 /* ======================================================================== */
 
 /* Turn ON if you want to use the following M68K variants */
-#define M68K_EMULATE_010            OPT_ON
-#define M68K_EMULATE_EC020          OPT_ON
-#define M68K_EMULATE_020            OPT_ON
-#define M68K_EMULATE_040            OPT_ON
+#define M68K_EMULATE_010            M68K_OPT_ON
+#define M68K_EMULATE_EC020          M68K_OPT_ON
+#define M68K_EMULATE_020            M68K_OPT_ON
+#define M68K_EMULATE_040            M68K_OPT_ON
 
 
 /* If ON, the CPU will call m68k_read_immediate_xx() for immediate addressing
  * and m68k_read_pcrelative_xx() for PC-relative addressing.
  * If off, all read requests from the CPU will be redirected to m68k_read_xx()
  */
-#define M68K_SEPARATE_READS         OPT_OFF
+#define M68K_SEPARATE_READS         M68K_OPT_OFF
 
 /* If ON, the CPU will call m68k_write_32_pd() when it executes move.l with a
  * predecrement destination EA mode instead of m68k_write_32().
  * To simulate real 68k behavior, m68k_write_32_pd() must first write the high
  * word to [address+2], and then write the low word to [address].
  */
-#define M68K_SIMULATE_PD_WRITES     OPT_OFF
+#define M68K_SIMULATE_PD_WRITES     M68K_OPT_OFF
 
 /* If ON, CPU will call the interrupt acknowledge callback when it services an
  * interrupt.
  * If off, all interrupts will be autovectored and all interrupt requests will
  * auto-clear when the interrupt is serviced.
  */
-#define M68K_EMULATE_INT_ACK        OPT_SPECIFY_HANDLER
+#define M68K_EMULATE_INT_ACK        M68K_OPT_SPECIFY_HANDLER
 #define M68K_INT_ACK_CALLBACK(A)    cpu_irq_ack(A)
 
 
 /* If ON, CPU will call the breakpoint acknowledge callback when it encounters
  * a breakpoint instruction and it is running a 68010+.
  */
-#define M68K_EMULATE_BKPT_ACK       OPT_OFF
+#define M68K_EMULATE_BKPT_ACK       M68K_OPT_OFF
 #define M68K_BKPT_ACK_CALLBACK()    your_bkpt_ack_handler_function()
 
 
 /* If ON, the CPU will monitor the trace flags and take trace exceptions
  */
-#define M68K_EMULATE_TRACE          OPT_OFF
+#define M68K_EMULATE_TRACE          M68K_OPT_OFF
 
 
 /* If ON, CPU will call the output reset callback when it encounters a reset
  * instruction.
  */
-#define M68K_EMULATE_RESET          OPT_SPECIFY_HANDLER
+#define M68K_EMULATE_RESET          M68K_OPT_SPECIFY_HANDLER
 #define M68K_RESET_CALLBACK()       cpu_pulse_reset()
 
 /* If ON, CPU will call the callback when it encounters a cmpi.l #v, dn
  * instruction.
  */
-#define M68K_CMPILD_HAS_CALLBACK     OPT_OFF
+#define M68K_CMPILD_HAS_CALLBACK     M68K_OPT_OFF
 #define M68K_CMPILD_CALLBACK(v,r)    your_cmpild_handler_function(v,r)
 
 
 /* If ON, CPU will call the callback when it encounters a rte
  * instruction.
  */
-#define M68K_RTE_HAS_CALLBACK       OPT_OFF
+#define M68K_RTE_HAS_CALLBACK       M68K_OPT_OFF
 #define M68K_RTE_CALLBACK()         your_rte_handler_function()
 
 /* If ON, CPU will call the callback when it encounters a tas
  * instruction.
  */
-#define M68K_TAS_HAS_CALLBACK       OPT_OFF
+#define M68K_TAS_HAS_CALLBACK       M68K_OPT_OFF
 #define M68K_TAS_CALLBACK()         your_tas_handler_function()
 
 /* If ON, CPU will call the callback when it encounters an illegal instruction
@@ -134,10 +134,10 @@
  * as a normal instruction, and the illegal exception in canceled. If it returns 0,
  * the exception occurs normally.
  * The callback looks like int callback(int opcode)
- * You should put OPT_SPECIFY_HANDLER here if you cant to use it, otherwise it will
+ * You should put M68K_OPT_SPECIFY_HANDLER here if you cant to use it, otherwise it will
  * use a dummy default handler and you'll have to call m68k_set_illg_instr_callback explicitely
  */
-#define M68K_ILLG_HAS_CALLBACK	    OPT_OFF
+#define M68K_ILLG_HAS_CALLBACK	    M68K_OPT_OFF
 #define M68K_ILLG_CALLBACK(opcode)  op_illg(opcode)
 
 /* If ON, CPU will call the set fc callback on every memory access to
@@ -146,41 +146,41 @@
  * want to properly emulate the m68010 or higher. (moves uses function codes
  * to read/write data from different address spaces)
  */
-#define M68K_EMULATE_FC             OPT_SPECIFY_HANDLER
+#define M68K_EMULATE_FC             M68K_OPT_SPECIFY_HANDLER
 #define M68K_SET_FC_CALLBACK(A)     cpu_set_fc(A)
 
 /* If ON, CPU will call the pc changed callback when it changes the PC by a
  * large value.  This allows host programs to be nicer when it comes to
  * fetching immediate data and instructions on a banked memory system.
  */
-#define M68K_MONITOR_PC             OPT_OFF
+#define M68K_MONITOR_PC             M68K_OPT_OFF
 #define M68K_SET_PC_CALLBACK(A)     your_pc_changed_handler_function(A)
 
 
 /* If ON, CPU will call the instruction hook callback before every
  * instruction.
  */
-#define M68K_INSTRUCTION_HOOK       OPT_SPECIFY_HANDLER
+#define M68K_INSTRUCTION_HOOK       M68K_OPT_SPECIFY_HANDLER
 #define M68K_INSTRUCTION_CALLBACK(pc) cpu_instr_callback(pc)
 
 
 /* If ON, the CPU will emulate the 4-byte prefetch queue of a real 68000 */
-#define M68K_EMULATE_PREFETCH       OPT_ON
+#define M68K_EMULATE_PREFETCH       M68K_OPT_ON
 
 
 /* If ON, the CPU will generate address error exceptions if it tries to
  * access a word or longword at an odd address.
  * NOTE: This is only emulated properly for 68000 mode.
  */
-#define M68K_EMULATE_ADDRESS_ERROR  OPT_ON
+#define M68K_EMULATE_ADDRESS_ERROR  M68K_OPT_ON
 
 
 /* Turn ON to enable logging of illegal instruction calls.
  * M68K_LOG_FILEHANDLE must be #defined to a stdio file stream.
  * Turn on M68K_LOG_1010_1111 to log all 1010 and 1111 calls.
  */
-#define M68K_LOG_ENABLE             OPT_OFF
-#define M68K_LOG_1010_1111          OPT_OFF
+#define M68K_LOG_ENABLE             M68K_OPT_OFF
+#define M68K_LOG_1010_1111          M68K_OPT_OFF
 #define M68K_LOG_FILEHANDLE         some_file_handle
 
 
@@ -194,7 +194,7 @@
 /* If ON, the enulation core will use 64-bit integers to speed up some
  * operations.
 */
-#define M68K_USE_64_BIT  OPT_ON
+#define M68K_USE_64_BIT  M68K_OPT_ON
 
 
 #include "sim.h"

--- a/example/m68kconf.h
+++ b/example/m68kconf.h
@@ -64,81 +64,117 @@
 /* ======================================================================== */
 
 /* Turn ON if you want to use the following M68K variants */
+#ifndef M68K_EMULATE_010
 #define M68K_EMULATE_010            M68K_OPT_ON
+#endif
+
+#ifndef M68K_EMULATE_EC020
 #define M68K_EMULATE_EC020          M68K_OPT_ON
+#endif
+
+#ifndef M68K_EMULATE_020
 #define M68K_EMULATE_020            M68K_OPT_ON
+#endif
+
+#ifndef M68K_EMULATE_030
+#define M68K_EMULATE_030            M68K_OPT_ON
+#endif
+
+#ifndef M68K_EMULATE_040
 #define M68K_EMULATE_040            M68K_OPT_ON
+#endif
 
 
 /* If ON, the CPU will call m68k_read_immediate_xx() for immediate addressing
  * and m68k_read_pcrelative_xx() for PC-relative addressing.
  * If off, all read requests from the CPU will be redirected to m68k_read_xx()
  */
+#ifndef M68K_SEPARATE_READS
 #define M68K_SEPARATE_READS         M68K_OPT_OFF
+#endif
 
 /* If ON, the CPU will call m68k_write_32_pd() when it executes move.l with a
  * predecrement destination EA mode instead of m68k_write_32().
  * To simulate real 68k behavior, m68k_write_32_pd() must first write the high
  * word to [address+2], and then write the low word to [address].
  */
+#ifndef M68K_SIMULATE_PD_WRITES
 #define M68K_SIMULATE_PD_WRITES     M68K_OPT_OFF
+#endif
 
 /* If ON, CPU will call the interrupt acknowledge callback when it services an
  * interrupt.
  * If off, all interrupts will be autovectored and all interrupt requests will
  * auto-clear when the interrupt is serviced.
  */
+#ifndef M68K_EMULATE_INT_ACK
 #define M68K_EMULATE_INT_ACK        M68K_OPT_SPECIFY_HANDLER
 #define M68K_INT_ACK_CALLBACK(A)    cpu_irq_ack(A)
+#endif
 
 
 /* If ON, CPU will call the breakpoint acknowledge callback when it encounters
  * a breakpoint instruction and it is running a 68010+.
  */
+#ifndef M68K_EMULATE_BKPT_ACK
 #define M68K_EMULATE_BKPT_ACK       M68K_OPT_OFF
 #define M68K_BKPT_ACK_CALLBACK()    your_bkpt_ack_handler_function()
+#endif
 
 
 /* If ON, the CPU will monitor the trace flags and take trace exceptions
  */
+#ifndef M68K_EMULATE_TRACE
 #define M68K_EMULATE_TRACE          M68K_OPT_OFF
+#endif
 
 
 /* If ON, CPU will call the output reset callback when it encounters a reset
  * instruction.
  */
+#ifndef M68K_EMULATE_RESET
 #define M68K_EMULATE_RESET          M68K_OPT_SPECIFY_HANDLER
 #define M68K_RESET_CALLBACK()       cpu_pulse_reset()
+#endif
 
 /* If ON, CPU will call the callback when it encounters a cmpi.l #v, dn
  * instruction.
  */
+#ifndef M68K_CMPILD_HAS_CALLBACK
 #define M68K_CMPILD_HAS_CALLBACK     M68K_OPT_OFF
 #define M68K_CMPILD_CALLBACK(v,r)    your_cmpild_handler_function(v,r)
+#endif
 
 
 /* If ON, CPU will call the callback when it encounters a rte
  * instruction.
  */
+#ifndef M68K_RTE_HAS_CALLBACK
 #define M68K_RTE_HAS_CALLBACK       M68K_OPT_OFF
 #define M68K_RTE_CALLBACK()         your_rte_handler_function()
+#endif
 
 /* If ON, CPU will call the callback when it encounters a tas
  * instruction.
  */
+#ifndef M68K_TAS_HAS_CALLBACK
 #define M68K_TAS_HAS_CALLBACK       M68K_OPT_OFF
 #define M68K_TAS_CALLBACK()         your_tas_handler_function()
+#endif
 
-/* If ON, CPU will call the callback when it encounters an illegal instruction
- * passing the opcode as argument. If the callback returns 1, then it's considered
- * as a normal instruction, and the illegal exception in canceled. If it returns 0,
- * the exception occurs normally.
+/* If ON, CPU will call the callback when it encounters an illegal instruction,
+ * passing the opcode as argument. If the callback returns 1, then it gets
+ * treated as a normal instruction, and the illegal exception in canceled. If it
+ * returns 0, the exception occurs normally.
  * The callback looks like int callback(int opcode)
- * You should put M68K_OPT_SPECIFY_HANDLER here if you cant to use it, otherwise it will
- * use a dummy default handler and you'll have to call m68k_set_illg_instr_callback explicitely
+ * You should put M68K_OPT_SPECIFY_HANDLER here if you can to use it, otherwise
+ * it will use a dummy default handler and you'll have to call
+ * m68k_set_illg_instr_callback explicitly.
  */
-#define M68K_ILLG_HAS_CALLBACK	    M68K_OPT_OFF
-#define M68K_ILLG_CALLBACK(opcode)  op_illg(opcode)
+#ifndef M68K_ILLG_HAS_CALLBACK
+#define M68K_ILLG_HAS_CALLBACK      M68K_OPT_OFF
+#define M68K_ILLG_CALLBACK(opcode)  your_op_illg_handler_function(opcode)
+#endif
 
 /* If ON, CPU will call the set fc callback on every memory access to
  * differentiate between user/supervisor, program/data access like a real
@@ -146,43 +182,63 @@
  * want to properly emulate the m68010 or higher. (moves uses function codes
  * to read/write data from different address spaces)
  */
+#ifndef M68K_EMULATE_FC
 #define M68K_EMULATE_FC             M68K_OPT_SPECIFY_HANDLER
 #define M68K_SET_FC_CALLBACK(A)     cpu_set_fc(A)
+#endif
 
 /* If ON, CPU will call the pc changed callback when it changes the PC by a
  * large value.  This allows host programs to be nicer when it comes to
  * fetching immediate data and instructions on a banked memory system.
  */
+#ifndef M68K_MONITOR_PC
 #define M68K_MONITOR_PC             M68K_OPT_OFF
 #define M68K_SET_PC_CALLBACK(A)     your_pc_changed_handler_function(A)
+#endif
 
 
 /* If ON, CPU will call the instruction hook callback before every
  * instruction.
  */
+#ifndef M68K_INSTRUCTION_HOOK
 #define M68K_INSTRUCTION_HOOK       M68K_OPT_SPECIFY_HANDLER
 #define M68K_INSTRUCTION_CALLBACK(pc) cpu_instr_callback(pc)
+#endif
 
 
 /* If ON, the CPU will emulate the 4-byte prefetch queue of a real 68000 */
+#ifndef M68K_EMULATE_PREFETCH
 #define M68K_EMULATE_PREFETCH       M68K_OPT_ON
+#endif
 
 
 /* If ON, the CPU will generate address error exceptions if it tries to
  * access a word or longword at an odd address.
  * NOTE: This is only emulated properly for 68000 mode.
  */
+#ifndef M68K_EMULATE_ADDRESS_ERROR
 #define M68K_EMULATE_ADDRESS_ERROR  M68K_OPT_ON
+#endif
 
 
 /* Turn ON to enable logging of illegal instruction calls.
  * M68K_LOG_FILEHANDLE must be #defined to a stdio file stream.
  * Turn on M68K_LOG_1010_1111 to log all 1010 and 1111 calls.
  */
+#ifndef M68K_LOG_ENABLE
 #define M68K_LOG_ENABLE             M68K_OPT_OFF
 #define M68K_LOG_1010_1111          M68K_OPT_OFF
 #define M68K_LOG_FILEHANDLE         some_file_handle
+#endif
 
+/*
+ * Emulate PMMU: if you enable this, there will be a test to see if the current
+ * chip has some enabled PMMU added to every memory access, so enable this only
+ * if it's useful.
+ */
+#ifndef M68K_EMULATE_PMMU
+#define M68K_EMULATE_PMMU           M68K_OPT_ON
+#endif
 
 /* ----------------------------- COMPATIBILITY ---------------------------- */
 
@@ -194,7 +250,9 @@
 /* If ON, the enulation core will use 64-bit integers to speed up some
  * operations.
 */
-#define M68K_USE_64_BIT  M68K_OPT_ON
+#ifndef M68K_USE_64_BIT
+#define M68K_USE_64_BIT             M68K_OPT_ON
+#endif
 
 
 #include "sim.h"

--- a/m68k.h
+++ b/m68k.h
@@ -34,8 +34,8 @@
 extern "C" {
 #endif
 
-#ifndef ARRAY_LENGTH
-#define ARRAY_LENGTH(x)         (sizeof(x) / sizeof(x[0]))
+#ifndef M68K_ARRAY_LENGTH
+#define M68K_ARRAY_LENGTH(x)         (sizeof(x) / sizeof(x[0]))
 #endif
 
 #ifndef FALSE
@@ -394,7 +394,7 @@ unsigned int m68k_disassemble_raw(char* str_buff, unsigned int pc, const unsigne
 /* ============================== MAME STUFF ============================== */
 /* ======================================================================== */
 
-#if M68K_COMPILE_FOR_MAME == OPT_ON
+#if M68K_COMPILE_FOR_MAME == M68K_OPT_ON
 #include "m68kmame.h"
 #endif /* M68K_COMPILE_FOR_MAME */
 

--- a/m68kconf.h
+++ b/m68kconf.h
@@ -34,14 +34,14 @@
 
 
 /* Configuration switches.
- * Use OPT_SPECIFY_HANDLER for configuration options that allow callbacks.
- * OPT_SPECIFY_HANDLER causes the core to link directly to the function
+ * Use M68K_OPT_SPECIFY_HANDLER for configuration options that allow callbacks.
+ * M68K_OPT_SPECIFY_HANDLER causes the core to link directly to the function
  * or macro you specify, rather than using callback functions whose pointer
  * must be passed in using m68k_set_xxx_callback().
  */
-#define OPT_OFF             0
-#define OPT_ON              1
-#define OPT_SPECIFY_HANDLER 2
+#define M68K_OPT_OFF             0
+#define M68K_OPT_ON              1
+#define M68K_OPT_SPECIFY_HANDLER 2
 
 
 /* ======================================================================== */
@@ -49,14 +49,14 @@
 /* ======================================================================== */
 
 /* If you're compiling this for MAME, only change M68K_COMPILE_FOR_MAME
- * to OPT_ON and use m68kmame.h to configure the 68k core.
+ * to M68K_OPT_ON and use m68kmame.h to configure the 68k core.
  */
 #ifndef M68K_COMPILE_FOR_MAME
-#define M68K_COMPILE_FOR_MAME      OPT_OFF
+#define M68K_COMPILE_FOR_MAME      M68K_OPT_OFF
 #endif /* M68K_COMPILE_FOR_MAME */
 
 
-#if M68K_COMPILE_FOR_MAME == OPT_OFF
+#if M68K_COMPILE_FOR_MAME == M68K_OPT_OFF
 
 
 /* ======================================================================== */
@@ -64,70 +64,70 @@
 /* ======================================================================== */
 
 /* Turn ON if you want to use the following M68K variants */
-#define M68K_EMULATE_010            OPT_ON
-#define M68K_EMULATE_EC020          OPT_ON
-#define M68K_EMULATE_020            OPT_ON
-#define M68K_EMULATE_030            OPT_ON
-#define M68K_EMULATE_040            OPT_ON
+#define M68K_EMULATE_010            M68K_OPT_ON
+#define M68K_EMULATE_EC020          M68K_OPT_ON
+#define M68K_EMULATE_020            M68K_OPT_ON
+#define M68K_EMULATE_030            M68K_OPT_ON
+#define M68K_EMULATE_040            M68K_OPT_ON
 
 
 /* If ON, the CPU will call m68k_read_immediate_xx() for immediate addressing
  * and m68k_read_pcrelative_xx() for PC-relative addressing.
  * If off, all read requests from the CPU will be redirected to m68k_read_xx()
  */
-#define M68K_SEPARATE_READS         OPT_OFF
+#define M68K_SEPARATE_READS         M68K_OPT_OFF
 
 /* If ON, the CPU will call m68k_write_32_pd() when it executes move.l with a
  * predecrement destination EA mode instead of m68k_write_32().
  * To simulate real 68k behavior, m68k_write_32_pd() must first write the high
  * word to [address+2], and then write the low word to [address].
  */
-#define M68K_SIMULATE_PD_WRITES     OPT_OFF
+#define M68K_SIMULATE_PD_WRITES     M68K_OPT_OFF
 
 /* If ON, CPU will call the interrupt acknowledge callback when it services an
  * interrupt.
  * If off, all interrupts will be autovectored and all interrupt requests will
  * auto-clear when the interrupt is serviced.
  */
-#define M68K_EMULATE_INT_ACK        OPT_OFF
+#define M68K_EMULATE_INT_ACK        M68K_OPT_OFF
 #define M68K_INT_ACK_CALLBACK(A)    your_int_ack_handler_function(A)
 
 
 /* If ON, CPU will call the breakpoint acknowledge callback when it encounters
  * a breakpoint instruction and it is running a 68010+.
  */
-#define M68K_EMULATE_BKPT_ACK       OPT_OFF
+#define M68K_EMULATE_BKPT_ACK       M68K_OPT_OFF
 #define M68K_BKPT_ACK_CALLBACK()    your_bkpt_ack_handler_function()
 
 
 /* If ON, the CPU will monitor the trace flags and take trace exceptions
  */
-#define M68K_EMULATE_TRACE          OPT_OFF
+#define M68K_EMULATE_TRACE          M68K_OPT_OFF
 
 
 /* If ON, CPU will call the output reset callback when it encounters a reset
  * instruction.
  */
-#define M68K_EMULATE_RESET          OPT_OFF
+#define M68K_EMULATE_RESET          M68K_OPT_OFF
 #define M68K_RESET_CALLBACK()       your_reset_handler_function()
 
 /* If ON, CPU will call the callback when it encounters a cmpi.l #v, dn
  * instruction.
  */
-#define M68K_CMPILD_HAS_CALLBACK     OPT_OFF
+#define M68K_CMPILD_HAS_CALLBACK     M68K_OPT_OFF
 #define M68K_CMPILD_CALLBACK(v,r)    your_cmpild_handler_function(v,r)
 
 
 /* If ON, CPU will call the callback when it encounters a rte
  * instruction.
  */
-#define M68K_RTE_HAS_CALLBACK       OPT_OFF
+#define M68K_RTE_HAS_CALLBACK       M68K_OPT_OFF
 #define M68K_RTE_CALLBACK()         your_rte_handler_function()
 
 /* If ON, CPU will call the callback when it encounters a tas
  * instruction.
  */
-#define M68K_TAS_HAS_CALLBACK       OPT_OFF
+#define M68K_TAS_HAS_CALLBACK       M68K_OPT_OFF
 #define M68K_TAS_CALLBACK()         your_tas_handler_function()
 
 /* If ON, CPU will call the callback when it encounters an illegal instruction
@@ -135,10 +135,10 @@
  * as a normal instruction, and the illegal exception in canceled. If it returns 0,
  * the exception occurs normally.
  * The callback looks like int callback(int opcode)
- * You should put OPT_SPECIFY_HANDLER here if you cant to use it, otherwise it will
+ * You should put M68K_OPT_SPECIFY_HANDLER here if you cant to use it, otherwise it will
  * use a dummy default handler and you'll have to call m68k_set_illg_instr_callback explicitely
  */
-#define M68K_ILLG_HAS_CALLBACK	    OPT_OFF
+#define M68K_ILLG_HAS_CALLBACK	    M68K_OPT_OFF
 #define M68K_ILLG_CALLBACK(opcode)  op_illg(opcode)
 
 /* If ON, CPU will call the set fc callback on every memory access to
@@ -147,46 +147,46 @@
  * want to properly emulate the m68010 or higher. (moves uses function codes
  * to read/write data from different address spaces)
  */
-#define M68K_EMULATE_FC             OPT_OFF
+#define M68K_EMULATE_FC             M68K_OPT_OFF
 #define M68K_SET_FC_CALLBACK(A)     your_set_fc_handler_function(A)
 
 /* If ON, CPU will call the pc changed callback when it changes the PC by a
  * large value.  This allows host programs to be nicer when it comes to
  * fetching immediate data and instructions on a banked memory system.
  */
-#define M68K_MONITOR_PC             OPT_OFF
+#define M68K_MONITOR_PC             M68K_OPT_OFF
 #define M68K_SET_PC_CALLBACK(A)     your_pc_changed_handler_function(A)
 
 
 /* If ON, CPU will call the instruction hook callback before every
  * instruction.
  */
-#define M68K_INSTRUCTION_HOOK       OPT_OFF
+#define M68K_INSTRUCTION_HOOK       M68K_OPT_OFF
 #define M68K_INSTRUCTION_CALLBACK(pc) your_instruction_hook_function(pc)
 
 
 /* If ON, the CPU will emulate the 4-byte prefetch queue of a real 68000 */
-#define M68K_EMULATE_PREFETCH       OPT_OFF
+#define M68K_EMULATE_PREFETCH       M68K_OPT_OFF
 
 
 /* If ON, the CPU will generate address error exceptions if it tries to
  * access a word or longword at an odd address.
  * NOTE: This is only emulated properly for 68000 mode.
  */
-#define M68K_EMULATE_ADDRESS_ERROR  OPT_OFF
+#define M68K_EMULATE_ADDRESS_ERROR  M68K_OPT_OFF
 
 
 /* Turn ON to enable logging of illegal instruction calls.
  * M68K_LOG_FILEHANDLE must be #defined to a stdio file stream.
  * Turn on M68K_LOG_1010_1111 to log all 1010 and 1111 calls.
  */
-#define M68K_LOG_ENABLE             OPT_OFF
-#define M68K_LOG_1010_1111          OPT_OFF
+#define M68K_LOG_ENABLE             M68K_OPT_OFF
+#define M68K_LOG_1010_1111          M68K_OPT_OFF
 #define M68K_LOG_FILEHANDLE         some_file_handle
 
 /* Emulate PMMU : if you enable this, there will be a test to see if the current chip has some enabled pmmu added to every memory access,
  * so enable this only if it's useful */
-#define M68K_EMULATE_PMMU   OPT_ON
+#define M68K_EMULATE_PMMU   M68K_OPT_ON
 
 /* ----------------------------- COMPATIBILITY ---------------------------- */
 
@@ -198,7 +198,7 @@
 /* If ON, the enulation core will use 64-bit integers to speed up some
  * operations.
 */
-#define M68K_USE_64_BIT  OPT_ON
+#define M68K_USE_64_BIT  M68K_OPT_ON
 
 
 #endif /* M68K_COMPILE_FOR_MAME */

--- a/m68kconf.h
+++ b/m68kconf.h
@@ -64,82 +64,117 @@
 /* ======================================================================== */
 
 /* Turn ON if you want to use the following M68K variants */
+#ifndef M68K_EMULATE_010
 #define M68K_EMULATE_010            M68K_OPT_ON
+#endif
+
+#ifndef M68K_EMULATE_EC020
 #define M68K_EMULATE_EC020          M68K_OPT_ON
+#endif
+
+#ifndef M68K_EMULATE_020
 #define M68K_EMULATE_020            M68K_OPT_ON
+#endif
+
+#ifndef M68K_EMULATE_030
 #define M68K_EMULATE_030            M68K_OPT_ON
+#endif
+
+#ifndef M68K_EMULATE_040
 #define M68K_EMULATE_040            M68K_OPT_ON
+#endif
 
 
 /* If ON, the CPU will call m68k_read_immediate_xx() for immediate addressing
  * and m68k_read_pcrelative_xx() for PC-relative addressing.
  * If off, all read requests from the CPU will be redirected to m68k_read_xx()
  */
+#ifndef M68K_SEPARATE_READS
 #define M68K_SEPARATE_READS         M68K_OPT_OFF
+#endif
 
 /* If ON, the CPU will call m68k_write_32_pd() when it executes move.l with a
  * predecrement destination EA mode instead of m68k_write_32().
  * To simulate real 68k behavior, m68k_write_32_pd() must first write the high
  * word to [address+2], and then write the low word to [address].
  */
+#ifndef M68K_SIMULATE_PD_WRITES
 #define M68K_SIMULATE_PD_WRITES     M68K_OPT_OFF
+#endif
 
 /* If ON, CPU will call the interrupt acknowledge callback when it services an
  * interrupt.
  * If off, all interrupts will be autovectored and all interrupt requests will
  * auto-clear when the interrupt is serviced.
  */
+#ifndef M68K_EMULATE_INT_ACK
 #define M68K_EMULATE_INT_ACK        M68K_OPT_OFF
 #define M68K_INT_ACK_CALLBACK(A)    your_int_ack_handler_function(A)
+#endif
 
 
 /* If ON, CPU will call the breakpoint acknowledge callback when it encounters
  * a breakpoint instruction and it is running a 68010+.
  */
+#ifndef M68K_EMULATE_BKPT_ACK
 #define M68K_EMULATE_BKPT_ACK       M68K_OPT_OFF
 #define M68K_BKPT_ACK_CALLBACK()    your_bkpt_ack_handler_function()
+#endif
 
 
 /* If ON, the CPU will monitor the trace flags and take trace exceptions
  */
+#ifndef M68K_EMULATE_TRACE
 #define M68K_EMULATE_TRACE          M68K_OPT_OFF
+#endif
 
 
 /* If ON, CPU will call the output reset callback when it encounters a reset
  * instruction.
  */
+#ifndef M68K_EMULATE_RESET
 #define M68K_EMULATE_RESET          M68K_OPT_OFF
 #define M68K_RESET_CALLBACK()       your_reset_handler_function()
+#endif
 
 /* If ON, CPU will call the callback when it encounters a cmpi.l #v, dn
  * instruction.
  */
+#ifndef M68K_CMPILD_HAS_CALLBACK
 #define M68K_CMPILD_HAS_CALLBACK     M68K_OPT_OFF
 #define M68K_CMPILD_CALLBACK(v,r)    your_cmpild_handler_function(v,r)
+#endif
 
 
 /* If ON, CPU will call the callback when it encounters a rte
  * instruction.
  */
+#ifndef M68K_RTE_HAS_CALLBACK
 #define M68K_RTE_HAS_CALLBACK       M68K_OPT_OFF
 #define M68K_RTE_CALLBACK()         your_rte_handler_function()
+#endif
 
 /* If ON, CPU will call the callback when it encounters a tas
  * instruction.
  */
+#ifndef M68K_TAS_HAS_CALLBACK
 #define M68K_TAS_HAS_CALLBACK       M68K_OPT_OFF
 #define M68K_TAS_CALLBACK()         your_tas_handler_function()
+#endif
 
-/* If ON, CPU will call the callback when it encounters an illegal instruction
- * passing the opcode as argument. If the callback returns 1, then it's considered
- * as a normal instruction, and the illegal exception in canceled. If it returns 0,
- * the exception occurs normally.
+/* If ON, CPU will call the callback when it encounters an illegal instruction,
+ * passing the opcode as argument. If the callback returns 1, then it gets
+ * treated as a normal instruction, and the illegal exception in canceled. If it
+ * returns 0, the exception occurs normally.
  * The callback looks like int callback(int opcode)
- * You should put M68K_OPT_SPECIFY_HANDLER here if you cant to use it, otherwise it will
- * use a dummy default handler and you'll have to call m68k_set_illg_instr_callback explicitely
+ * You should put M68K_OPT_SPECIFY_HANDLER here if you can to use it, otherwise
+ * it will use a dummy default handler and you'll have to call
+ * m68k_set_illg_instr_callback explicitly.
  */
-#define M68K_ILLG_HAS_CALLBACK	    M68K_OPT_OFF
-#define M68K_ILLG_CALLBACK(opcode)  op_illg(opcode)
+#ifndef M68K_ILLG_HAS_CALLBACK
+#define M68K_ILLG_HAS_CALLBACK      M68K_OPT_OFF
+#define M68K_ILLG_CALLBACK(opcode)  your_op_illg_handler_function(opcode)
+#endif
 
 /* If ON, CPU will call the set fc callback on every memory access to
  * differentiate between user/supervisor, program/data access like a real
@@ -147,46 +182,63 @@
  * want to properly emulate the m68010 or higher. (moves uses function codes
  * to read/write data from different address spaces)
  */
+#ifndef M68K_EMULATE_FC
 #define M68K_EMULATE_FC             M68K_OPT_OFF
 #define M68K_SET_FC_CALLBACK(A)     your_set_fc_handler_function(A)
+#endif
 
 /* If ON, CPU will call the pc changed callback when it changes the PC by a
  * large value.  This allows host programs to be nicer when it comes to
  * fetching immediate data and instructions on a banked memory system.
  */
+#ifndef M68K_MONITOR_PC
 #define M68K_MONITOR_PC             M68K_OPT_OFF
 #define M68K_SET_PC_CALLBACK(A)     your_pc_changed_handler_function(A)
+#endif
 
 
 /* If ON, CPU will call the instruction hook callback before every
  * instruction.
  */
+#ifndef M68K_INSTRUCTION_HOOK
 #define M68K_INSTRUCTION_HOOK       M68K_OPT_OFF
 #define M68K_INSTRUCTION_CALLBACK(pc) your_instruction_hook_function(pc)
+#endif
 
 
 /* If ON, the CPU will emulate the 4-byte prefetch queue of a real 68000 */
+#ifndef M68K_EMULATE_PREFETCH
 #define M68K_EMULATE_PREFETCH       M68K_OPT_OFF
+#endif
 
 
 /* If ON, the CPU will generate address error exceptions if it tries to
  * access a word or longword at an odd address.
  * NOTE: This is only emulated properly for 68000 mode.
  */
+#ifndef M68K_EMULATE_ADDRESS_ERROR
 #define M68K_EMULATE_ADDRESS_ERROR  M68K_OPT_OFF
+#endif
 
 
 /* Turn ON to enable logging of illegal instruction calls.
  * M68K_LOG_FILEHANDLE must be #defined to a stdio file stream.
  * Turn on M68K_LOG_1010_1111 to log all 1010 and 1111 calls.
  */
+#ifndef M68K_LOG_ENABLE
 #define M68K_LOG_ENABLE             M68K_OPT_OFF
 #define M68K_LOG_1010_1111          M68K_OPT_OFF
 #define M68K_LOG_FILEHANDLE         some_file_handle
+#endif
 
-/* Emulate PMMU : if you enable this, there will be a test to see if the current chip has some enabled pmmu added to every memory access,
- * so enable this only if it's useful */
-#define M68K_EMULATE_PMMU   M68K_OPT_ON
+/*
+ * Emulate PMMU: if you enable this, there will be a test to see if the current
+ * chip has some enabled PMMU added to every memory access, so enable this only
+ * if it's useful.
+ */
+#ifndef M68K_EMULATE_PMMU
+#define M68K_EMULATE_PMMU           M68K_OPT_ON
+#endif
 
 /* ----------------------------- COMPATIBILITY ---------------------------- */
 
@@ -198,7 +250,9 @@
 /* If ON, the enulation core will use 64-bit integers to speed up some
  * operations.
 */
-#define M68K_USE_64_BIT  M68K_OPT_ON
+#ifndef M68K_USE_64_BIT
+#define M68K_USE_64_BIT             M68K_OPT_ON
+#endif
 
 
 #endif /* M68K_COMPILE_FOR_MAME */

--- a/m68kcpu.c
+++ b/m68kcpu.c
@@ -1171,7 +1171,7 @@ void m68k_set_context(void* src)
 /* ============================== MAME STUFF ============================== */
 /* ======================================================================== */
 
-#if M68K_COMPILE_FOR_MAME == OPT_ON
+#if M68K_COMPILE_FOR_MAME == M68K_OPT_ON
 
 static struct {
 	UINT16 sr;

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -472,7 +472,7 @@ typedef uint32 uint64;
 
 /* Enable or disable callback functions */
 #if M68K_EMULATE_INT_ACK
-	#if M68K_EMULATE_INT_ACK == OPT_SPECIFY_HANDLER
+	#if M68K_EMULATE_INT_ACK == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_int_ack(A) M68K_INT_ACK_CALLBACK(A)
 	#else
 		#define m68ki_int_ack(A) CALLBACK_INT_ACK(A)
@@ -483,7 +483,7 @@ typedef uint32 uint64;
 #endif /* M68K_EMULATE_INT_ACK */
 
 #if M68K_EMULATE_BKPT_ACK
-	#if M68K_EMULATE_BKPT_ACK == OPT_SPECIFY_HANDLER
+	#if M68K_EMULATE_BKPT_ACK == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_bkpt_ack(A) M68K_BKPT_ACK_CALLBACK(A)
 	#else
 		#define m68ki_bkpt_ack(A) CALLBACK_BKPT_ACK(A)
@@ -493,7 +493,7 @@ typedef uint32 uint64;
 #endif /* M68K_EMULATE_BKPT_ACK */
 
 #if M68K_EMULATE_RESET
-	#if M68K_EMULATE_RESET == OPT_SPECIFY_HANDLER
+	#if M68K_EMULATE_RESET == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_output_reset() M68K_RESET_CALLBACK()
 	#else
 		#define m68ki_output_reset() CALLBACK_RESET_INSTR()
@@ -503,7 +503,7 @@ typedef uint32 uint64;
 #endif /* M68K_EMULATE_RESET */
 
 #if M68K_CMPILD_HAS_CALLBACK
-	#if M68K_CMPILD_HAS_CALLBACK == OPT_SPECIFY_HANDLER
+	#if M68K_CMPILD_HAS_CALLBACK == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_cmpild_callback(v,r) M68K_CMPILD_CALLBACK(v,r)
 	#else
 		#define m68ki_cmpild_callback(v,r) CALLBACK_CMPILD_INSTR(v,r)
@@ -513,7 +513,7 @@ typedef uint32 uint64;
 #endif /* M68K_CMPILD_HAS_CALLBACK */
 
 #if M68K_RTE_HAS_CALLBACK
-	#if M68K_RTE_HAS_CALLBACK == OPT_SPECIFY_HANDLER
+	#if M68K_RTE_HAS_CALLBACK == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_rte_callback() M68K_RTE_CALLBACK()
 	#else
 		#define m68ki_rte_callback() CALLBACK_RTE_INSTR()
@@ -523,7 +523,7 @@ typedef uint32 uint64;
 #endif /* M68K_RTE_HAS_CALLBACK */
 
 #if M68K_TAS_HAS_CALLBACK
-	#if M68K_TAS_HAS_CALLBACK == OPT_SPECIFY_HANDLER
+	#if M68K_TAS_HAS_CALLBACK == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_tas_callback() M68K_TAS_CALLBACK()
 	#else
 		#define m68ki_tas_callback() CALLBACK_TAS_INSTR()
@@ -533,7 +533,7 @@ typedef uint32 uint64;
 #endif /* M68K_TAS_HAS_CALLBACK */
 
 #if M68K_ILLG_HAS_CALLBACK
-	#if M68K_ILLG_HAS_CALLBACK == OPT_SPECIFY_HANDLER
+	#if M68K_ILLG_HAS_CALLBACK == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_illg_callback(opcode) M68K_ILLG_CALLBACK(opcode)
 	#else
 		#define m68ki_illg_callback(opcode) CALLBACK_ILLG_INSTR(opcode)
@@ -543,7 +543,7 @@ typedef uint32 uint64;
 #endif /* M68K_ILLG_HAS_CALLBACK */
 
 #if M68K_INSTRUCTION_HOOK
-	#if M68K_INSTRUCTION_HOOK == OPT_SPECIFY_HANDLER
+	#if M68K_INSTRUCTION_HOOK == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_instr_hook(pc) M68K_INSTRUCTION_CALLBACK(pc)
 	#else
 		#define m68ki_instr_hook(pc) CALLBACK_INSTR_HOOK(pc)
@@ -553,7 +553,7 @@ typedef uint32 uint64;
 #endif /* M68K_INSTRUCTION_HOOK */
 
 #if M68K_MONITOR_PC
-	#if M68K_MONITOR_PC == OPT_SPECIFY_HANDLER
+	#if M68K_MONITOR_PC == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_pc_changed(A) M68K_SET_PC_CALLBACK(ADDRESS_68K(A))
 	#else
 		#define m68ki_pc_changed(A) CALLBACK_PC_CHANGED(ADDRESS_68K(A))
@@ -565,7 +565,7 @@ typedef uint32 uint64;
 
 /* Enable or disable function code emulation */
 #if M68K_EMULATE_FC
-	#if M68K_EMULATE_FC == OPT_SPECIFY_HANDLER
+	#if M68K_EMULATE_FC == M68K_OPT_SPECIFY_HANDLER
 		#define m68ki_set_fc(A) M68K_SET_FC_CALLBACK(A)
 	#else
 		#define m68ki_set_fc(A) CALLBACK_SET_FC(A)
@@ -1869,7 +1869,7 @@ static inline void m68ki_exception_trace(void)
 
 	if(CPU_TYPE_IS_010_LESS(CPU_TYPE))
 	{
-		#if M68K_EMULATE_ADDRESS_ERROR == OPT_ON
+		#if M68K_EMULATE_ADDRESS_ERROR == M68K_OPT_ON
 		if(CPU_TYPE_IS_000(CPU_TYPE))
 		{
 			CPU_INSTR_MODE = INSTRUCTION_NO;
@@ -1894,7 +1894,7 @@ static inline void m68ki_exception_privilege_violation(void)
 {
 	uint sr = m68ki_init_exception();
 
-	#if M68K_EMULATE_ADDRESS_ERROR == OPT_ON
+	#if M68K_EMULATE_ADDRESS_ERROR == M68K_OPT_ON
 	if(CPU_TYPE_IS_000(CPU_TYPE))
 	{
 		CPU_INSTR_MODE = INSTRUCTION_NO;
@@ -1954,7 +1954,7 @@ extern int cpu_log_enabled;
 static inline void m68ki_exception_1010(void)
 {
 	uint sr;
-#if M68K_LOG_1010_1111 == OPT_ON
+#if M68K_LOG_1010_1111 == M68K_OPT_ON
 	M68K_DO_LOG_EMU((M68K_LOG_FILEHANDLE "%s at %08x: called 1010 instruction %04x (%s)\n",
 					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PPC), REG_IR,
 					 m68ki_disassemble_quick(ADDRESS_68K(REG_PPC))));
@@ -1973,7 +1973,7 @@ static inline void m68ki_exception_1111(void)
 {
 	uint sr;
 
-#if M68K_LOG_1010_1111 == OPT_ON
+#if M68K_LOG_1010_1111 == M68K_OPT_ON
 	M68K_DO_LOG_EMU((M68K_LOG_FILEHANDLE "%s at %08x: called 1111 instruction %04x (%s)\n",
 					 m68ki_cpu_names[CPU_TYPE], ADDRESS_68K(REG_PPC), REG_IR,
 					 m68ki_disassemble_quick(ADDRESS_68K(REG_PPC))));
@@ -1987,7 +1987,7 @@ static inline void m68ki_exception_1111(void)
 	USE_CYCLES(CYC_EXCEPTION[EXCEPTION_1111] - CYC_INSTRUCTION[REG_IR]);
 }
 
-#if M68K_ILLG_HAS_CALLBACK == OPT_SPECIFY_HANDLER
+#if M68K_ILLG_HAS_CALLBACK == M68K_OPT_SPECIFY_HANDLER
 extern int m68ki_illg_callback(int);
 #endif
 
@@ -2004,7 +2004,7 @@ static inline void m68ki_exception_illegal(void)
 
 	sr = m68ki_init_exception();
 
-	#if M68K_EMULATE_ADDRESS_ERROR == OPT_ON
+	#if M68K_EMULATE_ADDRESS_ERROR == M68K_OPT_ON
 	if(CPU_TYPE_IS_000(CPU_TYPE))
 	{
 		CPU_INSTR_MODE = INSTRUCTION_NO;
@@ -2068,7 +2068,7 @@ static inline void m68ki_exception_interrupt(uint int_level)
 	uint sr;
 	uint new_pc;
 
-	#if M68K_EMULATE_ADDRESS_ERROR == OPT_ON
+	#if M68K_EMULATE_ADDRESS_ERROR == M68K_OPT_ON
 	if(CPU_TYPE_IS_000(CPU_TYPE))
 	{
 		CPU_INSTR_MODE = INSTRUCTION_NO;

--- a/m68kdasm.c
+++ b/m68kdasm.c
@@ -138,7 +138,7 @@
 
 
 /* Opcode flags */
-#if M68K_COMPILE_FOR_MAME == OPT_ON
+#if M68K_COMPILE_FOR_MAME == M68K_OPT_ON
 #define SET_OPCODE_FLAGS(x)	g_opcode_type = x;
 #define COMBINE_OPCODE_FLAGS(x) ((x) | g_opcode_type | DASMFLAG_SUPPORTED)
 #else
@@ -3685,10 +3685,10 @@ static void build_opcode_table(void)
 	uint i;
 	uint opcode;
 	opcode_struct* ostruct;
-	opcode_struct opcode_info[ARRAY_LENGTH(g_opcode_info)];
+	opcode_struct opcode_info[M68K_ARRAY_LENGTH(g_opcode_info)];
 
 	memcpy(opcode_info, g_opcode_info, sizeof(g_opcode_info));
-	qsort((void *)opcode_info, ARRAY_LENGTH(opcode_info)-1, sizeof(opcode_info[0]), compare_nof_true_bits);
+	qsort((void *)opcode_info, M68K_ARRAY_LENGTH(opcode_info)-1, sizeof(opcode_info[0]), compare_nof_true_bits);
 
 	for(i=0;i<0x10000;i++)
 	{

--- a/readme.txt
+++ b/readme.txt
@@ -104,7 +104,7 @@ handling.
 
 To add proper interrupt handling:
 
-- In m68kconf.h, set M68K_EMULATE_INT_ACK to OPT_SPECIFY_HANDLER
+- In m68kconf.h, set M68K_EMULATE_INT_ACK to M68K_OPT_SPECIFY_HANDLER
 
 - In m68kconf.h, set M68K_INT_ACK_CALLBACK(A) to your interrupt acknowledge
   routine
@@ -153,8 +153,8 @@ To enable separate immediate reads:
     unsigned int  m68k_read_pcrelative_32(unsigned int address);
 
 - If you need to know the current PC (for banking and such), set
-  M68K_MONITOR_PC to OPT_SPECIFY_HANDLER, and set M68K_SET_PC_CALLBACK(A) to
-  your routine.
+  M68K_MONITOR_PC to M68K_OPT_SPECIFY_HANDLER, and set M68K_SET_PC_CALLBACK(A)
+  to your routine.
 
 - In the unlikely case where you need to emulate some PMMU in the immediate
   reads and/or pcrealtive stuff, you'll need to explicitely call the
@@ -195,7 +195,7 @@ function code pins:
 
 To emulate the function code pins:
 
-- In m68kconf.h, set M68K_EMULATE_FC to OPT_SPECIFY_HANDLER and set
+- In m68kconf.h, set M68K_EMULATE_FC to M68K_OPT_SPECIFY_HANDLER and set
   M68K_SET_FC_CALLBACK(A) to your function code handler function.
 
 - Your function code handler should select the proper address space for
@@ -291,9 +291,9 @@ MULTIPLE CPU EMULATION:
 The default is to use only one CPU.  To use more than one CPU in this core,
 there are some things to keep in mind:
 
-- To have different cpus call different functions, use OPT_ON instead of
-  OPT_SPECIFY_HANDLER, and use the m68k_set_xxx_callback() functions to set
-  your callback handlers on a per-cpu basis.
+- To have different cpus call different functions, use M68K_OPT_ON instead of
+  M68K_OPT_SPECIFY_HANDLER, and use the m68k_set_xxx_callback() functions to
+  set your callback handlers on a per-cpu basis.
 
 - Be sure to call set_cpu_type() for each CPU you use.
 


### PR DESCRIPTION
To ensure ease of interoperability, I've prefixed almost all of the preprocessor macros used by Musashi with `M68K_` since that's the common prefix in the public API. The only ones I've left alone are `TRUE` and `FALSE` and `NULL` since those are so universal.

I've also wrapped the preprocessor macros with `#ifdef` and `#endif` so the contents of m68kconf.h can be selectively overridden, meaning those using Musashi don't need to incorporate and change it or write their own from scratch and replace it.